### PR TITLE
Redirect /longform to Ghost Admin dashboard

### DIFF
--- a/apps/codeforafrica/.env
+++ b/apps/codeforafrica/.env
@@ -2,3 +2,4 @@ NEXT_PUBLIC_APP_LOGO_URL=https://res.cloudinary.com/code-for-africa/image/upload
 NEXT_PUBLIC_APP_NAME="Code for Africa"
 NEXT_PUBLIC_APP_URL="http://localhost:3002"
 NEXT_PUBLIC_IMAGE_DOMAINS="res.cloudinary.com,"
+GHOST_URL="https://longform.codeforafrica.org"

--- a/apps/codeforafrica/env.template
+++ b/apps/codeforafrica/env.template
@@ -3,9 +3,17 @@ NEXT_PUBLIC_APP_LOGO_URL=https://res.cloudinary.com/code-for-africa/image/upload
 NEXT_PUBLIC_APP_NAME="Code for Africa"
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
+# Ghost
+#
+GHOST_URL=
+# Admin URL is only need if different from normal URL
+GHOST_ADMIN_URL=
+
 # Google
+#
 GOOGLE_MAPS_API_KEY=
 
 # GITHUB
+#
 GITHUB_BACKEND_REPO=
 GITHUB_AUTH_ENDPOINT=

--- a/apps/codeforafrica/next.config.js
+++ b/apps/codeforafrica/next.config.js
@@ -12,6 +12,10 @@ const outputFileTracingRoot = PROJECT_ROOT
   ? path.resolve(__dirname, PROJECT_ROOT)
   : undefined;
 
+const ghostUrl =
+  process.env.GHOST_ADMIN_URL?.trim() || process.env.GHOST_URL?.trim();
+const ghostAdminUrl = new URL("/ghost", ghostUrl).toString();
+
 module.exports = withTM({
   images: {
     domains: process.env.NEXT_PUBLIC_IMAGE_DOMAINS?.split(",")
@@ -24,6 +28,16 @@ module.exports = withTM({
   output: "standalone",
   pageExtensions: ["page.js"],
   reactStrictMode: true,
+  async redirects() {
+    return [
+      {
+        source: "/longform/:path*",
+        destination: `${ghostAdminUrl}/:path*`,
+        permanent: false,
+        basePath: false,
+      },
+    ];
+  },
   webpack: (config) => {
     config.module.rules.push(
       {


### PR DESCRIPTION
## Description

To make it easier for content editors to access the Ghost admin dashboard, this PR adds a `/longform` redirect to Ghost admin dashboard using `GHOST_URL` or `GHOST_ADMIN_URL` env vars.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas

