### PR TITLE
Fix missing hero props & team member title mixed casing 

### DIFF
--- a/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.js
+++ b/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.js
@@ -43,7 +43,10 @@ const TeamMemberCard = React.forwardRef(function TeamMemberCard(props, ref) {
           }}
         >
           <RichTypography variant="body1SemiBold">{name}</RichTypography>
-          <RichTypography variant="body1" sx={{ mt: "5px" }}>
+          <RichTypography
+            variant="body1"
+            sx={{ mt: "5px", textTransform: "capitalize" }}
+          >
             {title}
           </RichTypography>
         </CardContent>

--- a/apps/codeforafrica/src/components/TeamMembers/TeamMembers.snap.js
+++ b/apps/codeforafrica/src/components/TeamMembers/TeamMembers.snap.js
@@ -47,7 +47,7 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
                   Allan Cheboi
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-body1 css-fna42f-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1q719gd-MuiTypography-root"
                 >
                   Senior investigations manager
                 </div>
@@ -89,7 +89,7 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
                   Amanda Strydom
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-body1 css-fna42f-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1q719gd-MuiTypography-root"
                 >
                   Senior programme manager
                 </div>
@@ -131,7 +131,7 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
                   Anita Igbine
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-body1 css-fna42f-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-body1 css-1q719gd-MuiTypography-root"
                 >
                   Investigative data analyst
                 </div>

--- a/apps/codeforafrica/src/lib/index.js
+++ b/apps/codeforafrica/src/lib/index.js
@@ -659,7 +659,7 @@ function getHomePageStaticProps() {
       title: "Code for Africa",
       sections: [
         {
-          ...getHero,
+          ...getHero(),
           slug: "hero",
         },
         {


### PR DESCRIPTION
## Description

 - [x] `getHero` is a method and not an object,
 - [x] `title` should be capitalized.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/180791232-720f5e68-95e5-48dc-8a42-367bc57f106f.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

