### PR TITLE
Remove required env

### DIFF
--- a/.github/workflows/codeforafrica-build-deploy.yml
+++ b/.github/workflows/codeforafrica-build-deploy.yml
@@ -66,7 +66,6 @@ jobs:
           build-args: |
             APP=${{ env.APP }}
             GOOGLE_MAPS_API_KEY=${{ secrets.GOOGLE_MAPS_API_KEY }}
-            NEXT_PUBLIC_IMAGE_DOMAINS=${{ env.NEXT_PUBLIC_IMAGE_DOMAINS }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ ARG NEXT_TELEMETRY_DISABLED=1 \
     # Since some pages are completely rendered during build, we need
     # GOOGLE_MAPS_API_KEY, IMAGE_DOMAINS defined in builder
     GOOGLE_MAPS_API_KEY="" \
-    NEXT_PUBLIC_IMAGE_DOMAINS="" \
     # APP is build time arg only. Shouldn't be used in the image.
     APP
 
@@ -43,8 +42,7 @@ COPY apps/${APP} ./apps/${APP}
 RUN pnpm install --recursive --offline --frozen-lockfile
 
 ENV NEXT_TELEMETRY_DISABLED=${NEXT_TELEMETRY_DISABLED} \
-    PROJECT_ROOT=${PROJECT_ROOT} \
-    NEXT_PUBLIC_IMAGE_DOMAINS=${NEXT_PUBLIC_IMAGE_DOMAINS}
+    PROJECT_ROOT=${PROJECT_ROOT}
 
 RUN pnpm --filter "${APP}" build
 

--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeforafrica",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the main CFA site.",


### PR DESCRIPTION
## Description
Removes `NEXT_PUBLIC_IMAGE_DOMAINS` from required build args since it's already in `.env` file.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
