### PR TITLE
Fix missing children prop in CMSContent

### DIFF
--- a/apps/codeforafrica/contrib/dokku/Dockerfile
+++ b/apps/codeforafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/codeforafrica-ui:1.0.28
+FROM codeforafrica/codeforafrica-ui:1.0.29

--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeforafrica",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the main CFA site.",

--- a/apps/codeforafrica/src/components/CMSContent/CMSContent.js
+++ b/apps/codeforafrica/src/components/CMSContent/CMSContent.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import React, { useEffect, useRef } from "react";
 
 const CMSContent = React.forwardRef(function CMSContent(
-  { sx, TypographyProps },
+  { children, sx, TypographyProps },
   ref
 ) {
   const typographyRef = useRef();
@@ -33,7 +33,9 @@ const CMSContent = React.forwardRef(function CMSContent(
       sx={{ px: { xs: 2.5, sm: 0 }, ...sx }}
       ref={ref}
     >
-      <RichTypography {...TypographyProps} ref={typographyRef} />
+      <RichTypography {...TypographyProps} ref={typographyRef}>
+        {children}
+      </RichTypography>
     </Section>
   );
 });

--- a/apps/codeforafrica/src/components/CMSContent/CMSContent.snap.js
+++ b/apps/codeforafrica/src/components/CMSContent/CMSContent.snap.js
@@ -4,6 +4,17 @@ exports[`<CMSContent /> renders unchanged 1`] = `
 <div>
   <section
     class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-1y3f71u-MuiContainer-root"
-  />
+  >
+    <div
+      class="MuiTypography-root MuiTypography-body1 css-n624xw-MuiTypography-root"
+    >
+      <h1>
+        Hello
+      </h1>
+      <p>
+        World
+      </p>
+    </div>
+  </section>
 </div>
 `;

--- a/apps/codeforafrica/src/pages/imprint/index.snap.js
+++ b/apps/codeforafrica/src/pages/imprint/index.snap.js
@@ -23,7 +23,18 @@ exports[`<Pages/Imprint /> renders unchanged 1`] = `
     </div>
     <section
       class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-fkrtdf-MuiContainer-root"
-    />
+    >
+      <div
+        class="MuiTypography-root MuiTypography-body1 css-n624xw-MuiTypography-root"
+      >
+        <h1>
+          Hello
+        </h1>
+        <p>
+          World
+        </p>
+      </div>
+    </section>
   </main>
 </div>
 `;

--- a/apps/codeforafrica/src/pages/privacy/index.snap.js
+++ b/apps/codeforafrica/src/pages/privacy/index.snap.js
@@ -23,7 +23,18 @@ exports[`<Pages/Privacy /> renders unchanged 1`] = `
     </div>
     <section
       class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-kylj5g-MuiContainer-root"
-    />
+    >
+      <div
+        class="MuiTypography-root MuiTypography-body1 css-n624xw-MuiTypography-root"
+      >
+        <h1>
+          Hello
+        </h1>
+        <p>
+          World
+        </p>
+      </div>
+    </section>
   </main>
 </div>
 `;


### PR DESCRIPTION
## Description

This PR ensures the children prop received by `CMSContent` component is passed down to `RichTypography` for rendering.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/183017835-d377b506-91c8-4f0c-9890-a202ca3330ca.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
