### PR TITLE
Fix /about pages

### DIFF
--- a/apps/codeforafrica/content/pages/about.md
+++ b/apps/codeforafrica/content/pages/about.md
@@ -45,9 +45,17 @@ our-mission:
     4. We operate in public. CfA promotes openness in our operations and in the work of our partners. All digital tools utilised are open source, and the organisation’s information is open data. CfA actively encourages documentation, sharing and collaboration, in addition to reuse of our own tools, programmes and processes, as well as those of our partners.
 
     5. We help build ecosystems. CfA actively marshals resources to support the growth of a pan-African ecosystem of civic technologists. Whenever possible, this means reusing existing tools, standards and platforms, encouraging integration and extension. CfA operates as a pan-African federation of organisations who are active members of a global community, leveraging each other’s knowledge and resources.
-team:
-  - 24c487bd-ba84-42df-825e-b11a532786ad
-  - 8f56e20e-eb6c-44f2-be0a-cf96e75a91fa
+guiding-principles:
+  title: Guiding principles
+  guiding-principle-list:
+    - be7a2c8c-3a4d-4625-a67e-73c27cdf9f54
+    - ce72cdab-36a4-49c4-812b-0efbbd8bf20d
+    - 7cd9eb88-7748-42fa-94f8-f0bd40c72686
+    - 92c0d6ac-e9b7-48c8-9126-dccd1f1994ae
+    - 147839fa-c8c6-44b1-92ae-3f40e12d292b
+    - 33c4db4a-4f99-4400-b4fd-6b47e02de85d
+our-team:
+  title: Our team
 our-partners:
   title: Our partners
   partners-list:
@@ -61,13 +69,6 @@ our-partners:
     - aa280d47-ee0c-4cf7-93aa-1fbe1a087439
     - 1079f9ae-0fbd-472b-bbfb-518145c28b1d
     - daa2a622-0277-44be-b302-dbc703f89522
-guiding-principles:
-  - be7a2c8c-3a4d-4625-a67e-73c27cdf9f54
-  - ce72cdab-36a4-49c4-812b-0efbbd8bf20d
-  - 7cd9eb88-7748-42fa-94f8-f0bd40c72686
-  - 92c0d6ac-e9b7-48c8-9126-dccd1f1994ae
-  - 147839fa-c8c6-44b1-92ae-3f40e12d292b
-  - 33c4db4a-4f99-4400-b4fd-6b47e02de85d
 our-impact:
   title: Our impact in numbers
   impact-list:
@@ -80,4 +81,10 @@ our-impact:
     - 4aa8e6ab-044d-4765-a8ec-ac0691a60f34
     - 68d049ee-6c49-4fcf-8f06-325e53fa32c0
     - c74aab50-4925-4a19-bd75-4eed0dc5d962
+get-in-touch:
+  title: Are you looking to start a new project?
+  subtitle: We'd love to hear more
+  action:
+    content: Get in touch
+    href: /contact
 ---

--- a/apps/codeforafrica/src/components/GetInTouch/GetInTouch.js
+++ b/apps/codeforafrica/src/components/GetInTouch/GetInTouch.js
@@ -10,17 +10,15 @@ import TwoToneBackground from "@/codeforafrica/components/TwoToneBackground";
 
 const GetInTouch = React.forwardRef(function GetInTouch(props, ref) {
   const {
-    action: { href, label },
+    action: { href, content },
     subtitle,
-    slug,
     title,
-    ...other
+    sx,
   } = props;
 
   return (
     <TwoToneBackground
-      sx={{ py: { xs: "82.5px", sm: "102.5px", md: "94.5" } }}
-      {...other}
+      sx={{ py: { xs: "82.5px", sm: "102.5px", md: "94.5" }, ...sx }}
       ref={ref}
     >
       <Section sx={{ px: { xs: 2.5, sm: 0 }, zIndex: 1 }}>
@@ -63,7 +61,7 @@ const GetInTouch = React.forwardRef(function GetInTouch(props, ref) {
               },
             }}
           >
-            {label}
+            {content}
           </Button>
         </Stack>
       </Section>

--- a/apps/codeforafrica/src/components/GetInTouch/GetInTouch.snap.js
+++ b/apps/codeforafrica/src/components/GetInTouch/GetInTouch.snap.js
@@ -36,7 +36,6 @@ exports[`<GetInTouch /> renders unchanged 1`] = `
               viewbox="0 0 24 24"
             />
           </span>
-          Get in touch
         </a>
       </div>
     </div>

--- a/apps/codeforafrica/src/components/GuidingPrinciplesCardList/GuidingPrinciplesCardList.js
+++ b/apps/codeforafrica/src/components/GuidingPrinciplesCardList/GuidingPrinciplesCardList.js
@@ -6,9 +6,9 @@ import GuidingPrinciplesCard from "../GuidingPrinciplesCard";
 
 const GuidingPrinciplesCardList = React.forwardRef(
   function GuidingPrinciplesCardList(props, ref) {
-    const { principles, title, ...other } = props;
+    const { list, title, ...other } = props;
 
-    if (!principles?.length) {
+    if (!list?.length) {
       return null;
     }
     return (
@@ -23,7 +23,7 @@ const GuidingPrinciplesCardList = React.forwardRef(
             justifyContent: "space-between",
           }}
         >
-          {principles.map((principle) => (
+          {list.map((principle) => (
             <Grid item key={principle.title}>
               <GuidingPrinciplesCard {...principle} />
             </Grid>

--- a/apps/codeforafrica/src/components/OurPartners/OurPartners.js
+++ b/apps/codeforafrica/src/components/OurPartners/OurPartners.js
@@ -24,10 +24,10 @@ const OurPartners = React.forwardRef(function OurPartners(props, ref) {
         {title}
       </RichTypography>
       <Grid container columns={10} justifyContent="flex-start">
-        {partners.map(({ logo, name, slug }) => {
-          const href = slug ? `/about/partners/${slug}` : undefined;
+        {partners.map(({ logo, name, href }) => {
           const Wrapper = href?.length ? Link : React.Fragment;
           const wrapperProps = href?.length ? { href } : undefined;
+
           return (
             <Grid item xs={5} sm={2} key={name}>
               <Wrapper {...wrapperProps}>

--- a/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.js
+++ b/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.js
@@ -13,6 +13,7 @@ const TeamMemberCardRoot = styled(Card, {
   backgroundColor: `${theme.palette.background.main}`,
   display: "flex",
   flexDirection: "column",
+  height: "100%",
   width: 150,
   [theme.breakpoints.only("sm")]: {
     padding: "0 7px",

--- a/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.snap.js
+++ b/apps/codeforafrica/src/components/TeamMemberCard/TeamMemberCard.snap.js
@@ -3,7 +3,7 @@
 exports[`<TeamMemberCard /> renders unchanged 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-m2run-MuiPaper-root-MuiCard-root"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-wixki0-MuiPaper-root-MuiCard-root"
   >
     <button
       class="MuiButtonBase-root MuiCardActionArea-root css-sl1uh6-MuiButtonBase-root-MuiCardActionArea-root"

--- a/apps/codeforafrica/src/components/TeamMemberCardList/TeamMemberCardList.js
+++ b/apps/codeforafrica/src/components/TeamMemberCardList/TeamMemberCardList.js
@@ -26,6 +26,7 @@ const TeamMemberCardList = React.forwardRef(function TeamMemberCardList(
         container
         rowSpacing={{ xs: 3, sm: 2.5, md: 5, lg: "36px" }}
         columnSpacing={{ xs: 3, md: "25.6px", lg: 6 }}
+        alignItems="stretch"
         flexWrap={{ xs: "nowrap", sm: "wrap" }}
         sx={{
           pr: { xs: 3, sm: 0 },

--- a/apps/codeforafrica/src/components/TeamMembers/TeamMembers.snap.js
+++ b/apps/codeforafrica/src/components/TeamMembers/TeamMembers.snap.js
@@ -14,13 +14,13 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
       class="MuiBox-root css-n6p80u"
     >
       <div
-        class="MuiGrid-root MuiGrid-container css-zv50xx-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-container css-1p3emjt-MuiGrid-root"
       >
         <div
           class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-m2run-MuiPaper-root-MuiCard-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-wixki0-MuiPaper-root-MuiCard-root"
             content="<p>Allan is CfA’s senior investigations manager at the iLAB &amp; ANCIR, managing a team of forensic data scientists/analysts and technologists in eight African countries. He also leads the iLAB team which conducts network analysis investigations into disinformation and influence operations, including Coordinated Inauthentic Behaviour (CIB) and organised crime networks.</p>
 "
             country="Kenya"
@@ -62,7 +62,7 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
           class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-m2run-MuiPaper-root-MuiCard-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-wixki0-MuiPaper-root-MuiCard-root"
             content="<p>Amanda is a senior programme manager at Code for Africa where she manages CivicSignal. CivicSignal uses machine learning and natural language processing to monitor and map media in Africa. Previously, she was managing editor for the African Network of Centres for Investigative Reporting (ANCIR) and night editor for the Mail &amp; Guardian Online.</p>
 "
             country="South Africa"
@@ -104,7 +104,7 @@ exports[`<TeamMembers /> renders unchanged 1`] = `
           class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
         >
           <div
-            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-m2run-MuiPaper-root-MuiCard-root"
+            class="MuiPaper-root MuiPaper-elevation MuiPaper-elevation0 MuiCard-root css-wixki0-MuiPaper-root-MuiCard-root"
             content="<p>Anita Igbine is an investigative data analyst working with the iLAB team at Code for Africa. She has a background in engineering and has contributed to two dossiers tracking coordinated inauthentic behavior across Africa. She has also trained journalists to utilize data and social media for stories. Anita is currently based in Abuja, Nigeria.</p>
 "
             country="Nigeria"

--- a/apps/codeforafrica/src/lib/api.netlify-cms/getGetInTouch.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/getGetInTouch.js
@@ -1,0 +1,7 @@
+import { getCollectionBySlug } from "./utils";
+
+export default function getGetInTouch() {
+  return getCollectionBySlug("content/pages", "about", ["get-in-touch"]).items[
+    "get-in-touch"
+  ];
+}

--- a/apps/codeforafrica/src/lib/api.netlify-cms/getOurGuidingPrinciples.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/getOurGuidingPrinciples.js
@@ -6,8 +6,11 @@ import { getCollectionBySlug } from "./utils";
 const pagesDir = join(process.cwd(), "content/pages");
 
 function getOurGuidingPrinciples() {
-  const list = getCollectionBySlug(pagesDir, "about", ["guiding-principles"])
-    .items["guiding-principles"];
+  const { title, "guiding-principle-list": principleIds } = getCollectionBySlug(
+    pagesDir,
+    "about",
+    ["guiding-principles"]
+  ).items["guiding-principles"];
   const allPrinciples = getGuidingPrinciples([
     "id",
     "title",
@@ -15,7 +18,9 @@ function getOurGuidingPrinciples() {
     "content",
   ]);
 
-  return list?.map((id) => allPrinciples.find((p) => p.id === id)) ?? null;
+  const list =
+    principleIds?.map((id) => allPrinciples.find((p) => p.id === id)) ?? null;
+  return { title, list };
 }
 
 export default getOurGuidingPrinciples;

--- a/apps/codeforafrica/src/lib/api.netlify-cms/getOurTeam.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/getOurTeam.js
@@ -1,0 +1,9 @@
+import { getCollectionBySlug } from "./utils";
+
+export default function geOurPartners() {
+  const {
+    "our-team": { title },
+  } = getCollectionBySlug("content/pages", "about", ["our-team"]).items;
+
+  return { title };
+}

--- a/apps/codeforafrica/src/lib/api.netlify-cms/getPartners.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/getPartners.js
@@ -6,5 +6,8 @@ const partnersDir = join(process.cwd(), "content/partners");
 
 export default function getPartners(fields) {
   const partners = getCollectionData(partnersDir, fields);
-  return partners;
+  return partners.map(({ slug = null, ...other }) => {
+    const href = slug ? `/about/partners/${slug}` : null;
+    return { ...other, slug, href };
+  });
 }

--- a/apps/codeforafrica/src/lib/api.netlify-cms/getTeam.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/getTeam.js
@@ -6,7 +6,10 @@ const teamDir = join(process.cwd(), "content/team");
 
 export default function getTeam(fields) {
   const teams = getCollectionData(teamDir, fields);
-  return teams.map((member) => {
-    return { ...member, href: `/about/members/${member.slug}` };
-  });
+  return teams
+    .filter((member) => !member.deactivated)
+    .map(({ slug = null, ...other }) => {
+      const href = slug ? `/about/members/${slug}` : null;
+      return { ...other, slug, href };
+    });
 }

--- a/apps/codeforafrica/src/lib/api.netlify-cms/index.js
+++ b/apps/codeforafrica/src/lib/api.netlify-cms/index.js
@@ -1,7 +1,9 @@
+import getGetInTouch from "./getGetInTouch";
 import getOurGuidingPrinciples from "./getOurGuidingPrinciples";
 import getOurImpact from "./getOurImpact";
 import getOurMission from "./getOurMission";
 import getOurPartners from "./getOurPartners";
+import getOurTeam from "./getOurTeam";
 import getPartners from "./getPartners";
 import getCmsProjects from "./getProjects";
 import getTeam from "./getTeam";
@@ -12,14 +14,16 @@ import getMeetOurTeam from "./sections/getMeetOurTeam";
 
 export {
   getCmsProjects,
+  getFooter,
+  getHeader,
   getHero,
+  getGetInTouch,
   getMeetOurTeam,
   getOurGuidingPrinciples,
   getOurImpact,
   getOurMission,
   getOurPartners,
+  getOurTeam,
   getPartners,
   getTeam,
-  getHeader,
-  getFooter,
 };

--- a/apps/codeforafrica/src/lib/index.js
+++ b/apps/codeforafrica/src/lib/index.js
@@ -1,16 +1,18 @@
 import fuse from "./api.fuse";
 import {
-  getPartners,
   getCmsProjects,
+  getFooter,
+  getGetInTouch,
+  getHeader,
   getHero,
   getMeetOurTeam,
-  getTeam,
+  getOurGuidingPrinciples,
   getOurImpact,
   getOurMission,
   getOurPartners,
-  getOurGuidingPrinciples,
-  getHeader,
-  getFooter,
+  getOurTeam,
+  getPartners,
+  getTeam,
 } from "./api.netlify-cms";
 
 import {
@@ -512,20 +514,15 @@ function getAboutMembersPageStaticProps() {
           slug: "hero",
         },
         {
-          slug: "our-team",
-          title: "Our team",
+          ...getOurTeam(),
+          pathname: "/about/members",
           tags: getMembersFieldTags(),
           team: getMembers(),
-          pathname: "/about/members",
+          slug: "our-team",
         },
         {
+          ...getGetInTouch(),
           slug: "get-in-touch",
-          title: "Are you looking to start a new project?",
-          subtitle: "We'd love to hear more.",
-          action: {
-            href: "/contact",
-            label: "Get in touch",
-          },
         },
       ],
       footer,
@@ -549,16 +546,15 @@ function getAboutPageStaticProps() {
           slug: "our-mission",
         },
         {
+          ...getOurGuidingPrinciples(),
           slug: "guiding-principles",
-          title: "Guiding Principles",
-          principles: getOurGuidingPrinciples(),
         },
 
         {
-          slug: "our-team",
-          title: "Our team",
+          ...getOurTeam(),
           tags: getMembersFieldTags(),
           team: getMembers(),
+          slug: "our-team",
         },
         {
           slug: "our-partners",
@@ -569,13 +565,8 @@ function getAboutPageStaticProps() {
           impact: getOurImpact("about"),
         },
         {
+          ...getGetInTouch(),
           slug: "get-in-touch",
-          title: "Are you looking to start a new project?",
-          subtitle: "We'd love to hear more.",
-          action: {
-            href: "/contact",
-            label: "Get in touch",
-          },
         },
       ],
       footer,
@@ -598,17 +589,12 @@ function getAboutPartnersPageStaticProps() {
         },
         {
           slug: "our-partners",
-          title: "Our partners",
-          partners,
+          // reuse title from /about but show *all* partners
+          partners: { ...getOurPartners(), list: partners },
         },
         {
+          ...getGetInTouch(),
           slug: "get-in-touch",
-          title: "Are you looking to start a new project?",
-          subtitle: "We'd love to hear more.",
-          action: {
-            href: "/contact",
-            label: "Get in touch",
-          },
         },
       ],
       footer,

--- a/apps/codeforafrica/src/pages/about/[unit]/index.page.js
+++ b/apps/codeforafrica/src/pages/about/[unit]/index.page.js
@@ -32,7 +32,6 @@ function Index({ crumbs, sections, ...props }) {
               <OurTeam
                 {...section}
                 sx={{
-                  bgcolor: "background.default",
                   py: { xs: 2.5, md: 0 },
                 }}
                 key={section.slug}

--- a/apps/codeforafrica/src/pages/about/[unit]/index.snap.js
+++ b/apps/codeforafrica/src/pages/about/[unit]/index.snap.js
@@ -22,7 +22,7 @@ exports[`<Pages/About/Members /> renders unchanged 1`] = `
       </div>
     </div>
     <div
-      class="MuiBox-root css-168cimh"
+      class="MuiBox-root css-1yep4fv"
     >
       <div
         class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-1clvkda-MuiContainer-root"
@@ -115,7 +115,6 @@ exports[`<Pages/About/Members /> renders unchanged 1`] = `
                 viewbox="0 0 24 24"
               />
             </span>
-            Get in touch
           </a>
         </div>
       </div>

--- a/apps/codeforafrica/src/pages/api/admin/config.js
+++ b/apps/codeforafrica/src/pages/api/admin/config.js
@@ -189,6 +189,8 @@ module.exports = {
               label: "Hero",
               name: "hero",
               widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
               fields: [
                 {
                   label: "Title",
@@ -230,11 +232,13 @@ module.exports = {
               label: "Our Mission",
               name: "our-mission",
               widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
               fields: [
                 {
                   label: "Title",
                   name: "title",
-                  widget: "text",
+                  widget: "string",
                 },
                 {
                   name: "description",
@@ -243,24 +247,55 @@ module.exports = {
               ],
             },
             {
-              label: "Our Team",
-              name: "team",
-              widget: "relation",
-              collection: "team",
-              search_fields: ["name"],
-              value_field: "id",
-              display_fields: ["name"],
-              multiple: true,
+              label: "Guiding Principles",
+              name: "guiding-principles",
+              widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
+              fields: [
+                {
+                  label: "Title",
+                  name: "title",
+                  widget: "string",
+                },
+                {
+                  label: "Guiding Principles",
+                  name: "guiding-principle-list",
+                  label_singular: "Guiding Principle",
+                  widget: "relation",
+                  collection: "guiding-principles",
+                  search_fields: ["title"],
+                  value_field: "id",
+                  display_fields: ["title"],
+                  multiple: true,
+                },
+              ],
+            },
+            {
+              label: "Our team",
+              name: "our-team",
+              widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
+              fields: [
+                {
+                  label: "Title",
+                  name: "title",
+                  widget: "string",
+                },
+              ],
             },
             {
               label: "Our partners",
               name: "our-partners",
               widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
               fields: [
                 {
                   label: "Title",
                   name: "title",
-                  widget: "markdown",
+                  widget: "string",
                 },
                 {
                   label: "Partners",
@@ -275,20 +310,11 @@ module.exports = {
               ],
             },
             {
-              label: "Guiding Principles",
-              name: "guiding-principles",
-              label_singular: "Guiding Principle",
-              widget: "relation",
-              collection: "guiding-principles",
-              search_fields: ["title"],
-              value_field: "id",
-              display_fields: ["title"],
-              multiple: true,
-            },
-            {
               label: "Our Impact",
               name: "our-impact",
               widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
               fields: [
                 {
                   label: "Title",
@@ -304,6 +330,40 @@ module.exports = {
                   value_field: "id",
                   display_fields: ["title"],
                   multiple: true,
+                },
+              ],
+            },
+            {
+              label: "Get in touch",
+              name: "get-in-touch",
+              widget: "object",
+              collapsed: true,
+              summary: "{{fields.title}}",
+              fields: [
+                {
+                  label: "Title",
+                  name: "title",
+                  widget: "string",
+                },
+                {
+                  label: "Subtitle",
+                  name: "subtitle",
+                  widget: "string",
+                },
+                {
+                  label: "Action",
+                  name: "action",
+                  widget: "object",
+                  fields: [
+                    {
+                      name: "content",
+                      widget: "string",
+                    },
+                    {
+                      name: "href",
+                      widget: "string",
+                    },
+                  ],
                 },
               ],
             },
@@ -927,6 +987,12 @@ module.exports = {
           label: "Team",
           name: "team",
           widget: "string",
+        },
+        {
+          label: "Deactivated",
+          name: "deactivated",
+          widget: "boolean",
+          default: false,
         },
       ],
     },


### PR DESCRIPTION
## Description

- [x] Ensure `/about/members` uses background.main background,
- [x] Ensure `TeamMemberCardList` stretches cards to have equal height,
- [x] Add `deactivated` prop on team members to allow hiding of a team member without having to delete them. This is because we don't allow any selection on on /about page,
- [x] Ensure `/about/partners` loads partners ([currently](https://cfa.dev.codeforafrica.org/about/partners) they're missing),
- [x] Ensure **Get Involved** loads content from CMS, and
- [x] Ensure all components in `/about` page have their content editable and loadable from CMS.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot 2022-08-16 at 16-39-54 About Code for Africa](https://user-images.githubusercontent.com/1779590/184893958-95fc703e-b0e6-480e-a51b-357c19da2340.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

