### PR TITLE
Update to match CMS content.

### DIFF
--- a/apps/charterafrica/src/components/Ecosystem/Key.js
+++ b/apps/charterafrica/src/components/Ecosystem/Key.js
@@ -31,7 +31,7 @@ const Key = React.forwardRef(function Key(props, ref) {
             display="flex"
             flexWrap="nowrap"
             gap={1.25}
-            key={datum.label}
+            key={datum.id || datum.label}
           >
             <Box
               borderRadius={7}

--- a/apps/charterafrica/src/components/FocalCountries/FocalCountries.js
+++ b/apps/charterafrica/src/components/FocalCountries/FocalCountries.js
@@ -103,7 +103,15 @@ const FocalCountries = React.forwardRef(function FocalCountries(props, ref) {
                 >
                   {title}
                 </RichTypography>
-                <RichText elements={description} />
+                <RichText
+                  elements={description}
+                  sx={{
+                    mb: 2.5,
+                    "&:last-of-type": {
+                      mb: 0,
+                    },
+                  }}
+                />
               </Box>
             </Grid>
             <Grid item xs={12} sm={6} order={{ xs: 1, sm: 0 }}>

--- a/apps/charterafrica/src/components/FocalCountries/Popup.js
+++ b/apps/charterafrica/src/components/FocalCountries/Popup.js
@@ -1,3 +1,4 @@
+import { Link } from "@commons-ui/next";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
@@ -86,14 +87,18 @@ const Popup = React.forwardRef(function Popup(props, ref) {
           ))}
         </Box>
       ) : null}
-      <Button
-        color="primary"
-        onClick={onClose}
-        size="small"
-        variant="contained"
-      >
-        {link?.content}
-      </Button>
+      {link?.label ? (
+        <Button
+          color="primary"
+          component={link.href ? Link : undefined}
+          href={link.href}
+          onClick={onClose}
+          size="small"
+          variant="contained"
+        >
+          {link.label}
+        </Button>
+      ) : null}
     </Box>
   );
 });

--- a/apps/charterafrica/src/components/Hero/Slide.js
+++ b/apps/charterafrica/src/components/Hero/Slide.js
@@ -49,19 +49,20 @@ const Slide = React.forwardRef(function Slide(props, ref) {
             textAlign="center"
             typography={{ md: "display2" }}
             variant="h2Small"
-            sx={() => ({
+            sx={(t) => ({
               color: title?.color,
-              minHeight: `calc(${theme.typography.h2Small.fontSize}px*${theme.typography.h2Small.lineHeight}*3)`,
-              "&>em": {
+              minHeight: `calc(${t.typography.h2Small.fontSize}px*${t.typography.h2Small.lineHeight}*3)`,
+              whiteSpace: "pre-line",
+              "& > em, & > strong": {
                 color: "secondary.main",
                 fontStyle: "normal",
               },
-              [theme.breakpoints.up("sm")]: {
-                minHeight: `calc(${theme.typography.h2Small.fontSize}px*${theme.typography.h2Small.lineHeight}*2)`,
+              [t.breakpoints.up("sm")]: {
+                minHeight: `calc(${t.typography.h2Small.fontSize}px*${t.typography.h2Small.lineHeight}*2)`,
               },
-              [theme.breakpoints.up("md")]: {
+              [t.breakpoints.up("md")]: {
                 typography: "display2",
-                minHeight: `calc(${theme.typography.display2.fontSize}px*${theme.typography.display2.lineHeight}*2)`,
+                minHeight: `calc(${t.typography.display2.fontSize}px*${t.typography.display2.lineHeight}*2)`,
               },
             })}
           />
@@ -71,15 +72,15 @@ const Slide = React.forwardRef(function Slide(props, ref) {
             textAlign="center"
             variant="p1"
             lineHeight
-            sx={() => ({
+            sx={(t) => ({
               color: subheading?.color,
-              minHeight: `calc(${theme.typography.p1.fontSize}px*${theme.typography.p1.lineHeight}*2)`,
-              [theme.breakpoints.up("sm")]: {
-                minHeight: `calc(${theme.typography.p1.fontSize}px*${theme.typography.p1.lineHeight})`,
+              minHeight: `calc(${t.typography.p1.fontSize}px*${t.typography.p1.lineHeight}*2)`,
+              [t.breakpoints.up("sm")]: {
+                minHeight: `calc(${t.typography.p1.fontSize}px*${t.typography.p1.lineHeight})`,
               },
-              [theme.breakpoints.up("md")]: {
+              [t.breakpoints.up("md")]: {
                 typography: "subheading",
-                minHeight: `calc(${theme.typography.subheading.fontSize}px*${theme.typography.subheading.lineHeight}*2)`,
+                minHeight: `calc(${t.typography.subheading.fontSize}px*${t.typography.subheading.lineHeight}*2)`,
               },
             })}
           >

--- a/apps/charterafrica/src/payload/blocks/Ecosystem.js
+++ b/apps/charterafrica/src/payload/blocks/Ecosystem.js
@@ -45,7 +45,6 @@ const Ecosystem = {
               type: "number",
               required: true,
               min: 0,
-              max: 100,
               label: {
                 en: "Value",
                 fr: "Valeur",

--- a/apps/charterafrica/src/payload/blocks/Hero.js
+++ b/apps/charterafrica/src/payload/blocks/Hero.js
@@ -28,6 +28,21 @@ const Hero = {
           type: "group",
           fields: [
             {
+              name: "content",
+              type: "richText",
+              label: {
+                en: "Content",
+                fr: "Contenu",
+                pt: "Conteúdo",
+              },
+              required: true,
+              localized: true,
+              admin: {
+                elements: [],
+                leaves: ["bold", "italic", "underline", "code"],
+              },
+            },
+            {
               name: "color",
               type: "text",
               validate: validateHexColor,
@@ -36,21 +51,6 @@ const Hero = {
                 en: "Color",
                 fr: "Couleur",
                 pt: "Cor",
-              },
-            },
-            {
-              name: "content",
-              type: "richText",
-              label: {
-                en: "Title",
-                fr: "Titre",
-                pt: "Título",
-              },
-              required: true,
-              localized: true,
-              admin: {
-                elements: ["h1"],
-                leaves: ["bold", "italic", "underline", "code"],
               },
             },
           ],
@@ -67,17 +67,6 @@ const Hero = {
           required: true,
           fields: [
             {
-              name: "color",
-              type: "text",
-              validate: validateHexColor,
-              required: true,
-              label: {
-                en: "Color",
-                fr: "Couleur",
-                pt: "Cor",
-              },
-            },
-            {
               name: "content",
               type: "text",
               required: true,
@@ -86,6 +75,17 @@ const Hero = {
                 en: "Content",
                 fr: "Contenu",
                 pt: "Conteúdo",
+              },
+            },
+            {
+              name: "color",
+              type: "text",
+              validate: validateHexColor,
+              required: true,
+              label: {
+                en: "Color",
+                fr: "Couleur",
+                pt: "Cor",
               },
             },
           ],

--- a/apps/charterafrica/src/payload/fields/richText.js
+++ b/apps/charterafrica/src/payload/fields/richText.js
@@ -1,0 +1,57 @@
+import { deepmerge } from "@mui/utils";
+
+import mapLinkTypeToHref from "../utils/mapLinkTypeToHref";
+
+async function insertHref(nodes, payload) {
+  if (!nodes?.length) {
+    // Front-end needs `null` for serialization
+    return null;
+  }
+  return Promise.all(
+    nodes.map(async (node) => {
+      let newNode = node;
+      // The most important thing is not to change the doc structure
+      // since the admin UI expects it to be in certain why. But of course,
+      // we can add href prop for front-end.
+      if (node.type === "link") {
+        let { doc } = node;
+        if (typeof doc.value === "string") {
+          const { relationTo: collection, value: id } = doc;
+          const value = await payload.findByID({
+            collection,
+            id,
+            // We only need slug from the collection don't expand the whole
+            // relationship. We may end up getting stuck on infinite recursion if
+            // collection contain other links.
+            depth: 0,
+          });
+          doc = { ...doc, value };
+        }
+        const href = mapLinkTypeToHref({ ...node, doc });
+        newNode = { ...node, href };
+      }
+      newNode.children = await insertHref(node.children, payload);
+      return newNode;
+    })
+  );
+}
+
+async function mapLinkToHrefAfterRead({ req: { payload }, value }) {
+  if (!value?.length) {
+    return value;
+  }
+  return insertHref(value, payload);
+}
+
+function richText(overrides) {
+  const richTextResult = {
+    type: "richText",
+    hooks: {
+      afterRead: [mapLinkToHrefAfterRead],
+    },
+  };
+
+  return deepmerge(richTextResult, overrides);
+}
+
+export default richText;

--- a/apps/charterafrica/src/payload/globals/FocalCountries.js
+++ b/apps/charterafrica/src/payload/globals/FocalCountries.js
@@ -1,6 +1,7 @@
 import { array } from "payload/dist/fields/validations";
 
 import linkGroup from "../fields/linkGroup";
+import richText from "../fields/richText";
 
 const FocalCountries = {
   slug: "focal-countries",
@@ -24,19 +25,18 @@ const FocalCountries = {
       localized: true,
       required: true,
     },
-    {
+    richText({
       name: "description",
       label: {
         en: "Description",
         pt: "Descrição",
       },
-      type: "richText",
       localized: true,
       required: true,
       admin: {
         elements: ["h2", "h3", "h4", "h5", "h6", "ol", "ul", "link"],
       },
-    },
+    }),
     {
       name: "countries",
       label: {

--- a/apps/charterafrica/src/payload/globals/Helpdesk.js
+++ b/apps/charterafrica/src/payload/globals/Helpdesk.js
@@ -1,14 +1,4 @@
-import link from "../fields/link";
-import mapLinkTypeToHref from "../utils/mapLinkTypeToHref";
-
-function afterReadInsertLinkHrefHook(args) {
-  const { doc } = args;
-  if (doc.link) {
-    const { link: originalLink } = doc;
-    return { ...doc, link: mapLinkTypeToHref(originalLink) };
-  }
-  return doc;
-}
+import linkGroup from "../fields/linkGroup";
 
 const Helpdesk = {
   slug: "helpdesk",
@@ -53,16 +43,7 @@ const Helpdesk = {
             elements: ["ol", "ul", "link"],
           },
         },
-        {
-          name: "link",
-          label: {
-            en: "Link",
-            fr: "Lien",
-          },
-          type: "group",
-          fields: [link()],
-          required: true,
-        },
+        linkGroup(),
       ],
       admin: {
         initCollapsed: true,
@@ -96,11 +77,6 @@ const Helpdesk = {
       },
     },
   ],
-  hooks: {
-    // TODO(kilemensi): Check why if we add a hook to add src to image,
-    //                  admin UI fails.
-    afterRead: [afterReadInsertLinkHrefHook],
-  },
 };
 
 export default Helpdesk;


### PR DESCRIPTION
## Description

Now that we're primary using CMS to drive the website, a few components on the homepage needs tweaking:

 - [x] Hero should handle soft line break (`\n` using `whitespace: pre-line;` css),
 - [x] Ecosystem should use `id` in key when available & no need to specify maximum values,
 - [x] Use of `link.label` instead of `link.content`,
 - [ ] custom `richText` field that translate internal/url link to `href`, and
 - [ ] Use of `linkGroup` in `Helpdesk`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![Screenshot 2023-01-23 at 15-15-15 charter AFRICA](https://user-images.githubusercontent.com/1779590/214037416-a8c60bb1-7edc-464f-b8f2-396a886af17f.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

