### PR TITLE
@/charterafrica  Build

### DIFF
--- a/Dockerfile.charterafrica
+++ b/Dockerfile.charterafrica
@@ -1,0 +1,61 @@
+FROM node:16-alpine as node-alpine
+
+# Always install security updated e.g. https://pythonspeed.com/articles/security-updates-in-docker/
+# Update local cache so that other stages don't need to update cache
+RUN apk update \
+    && apk upgrade
+
+
+FROM node-alpine as base
+
+# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
+RUN apk add libc6-compat
+
+ARG PNPM_VERSION=7.4.0
+
+RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+
+WORKDIR /workspace
+
+COPY pnpm-lock.yaml .
+
+RUN pnpm fetch
+
+
+FROM base as builder
+
+ARG NEXT_TELEMETRY_DISABLED=1
+
+WORKDIR /workspace
+
+COPY *.yaml *.json ./
+COPY packages ./packages
+COPY apps/charterafrica ./apps/charterafrica
+
+# Use virtual store: https://pnpm.io/cli/fetch#usage-scenario
+RUN pnpm install --recursive --offline --frozen-lockfile
+
+RUN pnpm build --filter=charterafrica
+
+# TODO(kilemensi): Optimize and improve this default runner
+#                    i) Start with node-alpine or base and only copy/install
+#                       what's needed in prod
+#                   ii) Add user:group for security (nextjs:node)
+#                  iii) ?
+FROM builder as runner
+
+# Remember to remove local cache from runner
+RUN rm -rf /var/cache/apk/*
+
+ARG NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=${NEXT_TELEMETRY_DISABLED} \
+    PORT=${PORT}
+
+WORKDIR /workspace/apps/charterafrica
+
+EXPOSE ${PORT}
+
+ENTRYPOINT [ "node", "server" ]

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -50,6 +50,7 @@
     "@nivo/waffle": "^0.80.0",
     "@payloadcms/plugin-cloud-storage": "^1.0.12",
     "@payloadcms/plugin-seo": "^1.0.9",
+    "dotenv": "^16.0.3",
     "express": "^4.18.2",
     "leaflet": "^1.9.3",
     "nanoid": "^4.0.0",

--- a/apps/charterafrica/payload.config.js
+++ b/apps/charterafrica/payload.config.js
@@ -1,6 +1,9 @@
+import path from "path";
+
 import { cloudStorage } from "@payloadcms/plugin-cloud-storage";
 import { s3Adapter } from "@payloadcms/plugin-cloud-storage/s3";
 import seo from "@payloadcms/plugin-seo";
+import dotenv from "dotenv";
 import { buildConfig } from "payload/config";
 
 import Media from "./src/payload/collections/Media";
@@ -13,6 +16,16 @@ import Helpdesk from "./src/payload/globals/Helpdesk";
 import Navigation from "./src/payload/globals/Navigation";
 import Settings from "./src/payload/globals/Settings";
 import { defaultLocale, locales } from "./src/payload/utils/locales";
+
+// We can't use @next/env to load env vars here (unlike in server.js) because
+// this config is used on admin UI i.e. browser, and things like process.cwd
+// are not available on browser. We can manually [mock](https://payloadcms.com/docs/admin/webpack#aliasing-server-only-modules)
+// them but it's faster to just use dotenv since Payload has already done the
+// mocking for us.
+// Load .env
+dotenv.config();
+// Load .env.local
+dotenv.config({ path: path.resolve(__dirname, "./.env.local") });
 
 const appURL = process.env.PAYLOAD_PUBLIC_APP_URL;
 
@@ -51,6 +64,8 @@ export default buildConfig({
         ...config.resolve,
         fallback: {
           ...config.resolve.fallback,
+          fs: false,
+          os: false,
           "process/browser": false,
         },
       },

--- a/apps/charterafrica/server.js
+++ b/apps/charterafrica/server.js
@@ -15,6 +15,13 @@ const dev = process.env.NODE_ENV !== "production";
 const port = process.env.PORT || 3000;
 const sendGridAPIKey = process.env.SENDGRID_API_KEY;
 
+// Make sure commands gracefully respect termination signals (e.g. from Docker)
+// Allow the graceful termination to be manually configurable
+if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
+  process.on("SIGTERM", () => process.exit(0));
+  process.on("SIGINT", () => process.exit(0));
+}
+
 const server = express();
 
 payload.init({

--- a/apps/charterafrica/src/pages/index.page.js
+++ b/apps/charterafrica/src/pages/index.page.js
@@ -32,7 +32,7 @@ function Index({ blocks }) {
   });
 }
 
-export async function getStaticProps({ defaultLocale, locale, locales }) {
+export async function getServerSideProps({ defaultLocale, locale, locales }) {
   const { menus } = await payload.findGlobal("navigation", {
     locale,
     fallbackLocale: defaultLocale,

--- a/apps/charterafrica/src/payload/globals/Settings.js
+++ b/apps/charterafrica/src/payload/globals/Settings.js
@@ -1,34 +1,6 @@
 import { array } from "payload/dist/fields/validations";
 
-import link from "../fields/link";
-import linkArray from "../fields/linkArray";
 import { locales } from "../utils/locales";
-
-const linkField = link();
-linkField.fields.push({
-  type: "row",
-  fields: [
-    linkArray({
-      overrides: {
-        name: "children",
-        label: {
-          en: "Submenus",
-          fr: "Sous-menus",
-        },
-        labels: {
-          singular: {
-            en: "Submenu",
-            fr: "Sous-menu",
-          },
-          plural: {
-            en: "Submenus",
-            fr: "Sous-menus",
-          },
-        },
-      },
-    }),
-  ],
-});
 
 const Settings = {
   slug: "settings",
@@ -47,7 +19,7 @@ const Settings = {
         fr: "Titre & description",
         pt: "Titulo & descrição",
       },
-      type: "collapsible", // required
+      type: "collapsible",
       fields: [
         {
           name: "title",
@@ -81,7 +53,7 @@ const Settings = {
         ft: "Langues",
         pt: "Idiomas",
       },
-      type: "collapsible", // required
+      type: "collapsible",
       fields: [
         {
           name: "languages",

--- a/apps/charterafrica/src/payload/utils/locales.js
+++ b/apps/charterafrica/src/payload/utils/locales.js
@@ -1,5 +1,5 @@
 export const locales = process.env.PAYLOAD_PUBLIC_LOCALES?.split(",")
   ?.map((l) => l.trim())
-  .filter(Boolean);
+  .filter(Boolean) || ["en"];
 export const defaultLocale =
   process.env.PAYLOAD_PUBLIC_DEFAULT_LOCALE?.trim() || locales?.[0];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ importers:
       "@types/node": ^16.18.6
       "@types/react": ^18.0.26
       babel-jest: ^29.3.1
+      dotenv: ^16.0.3
       eslint: ^8.29.0
       eslint-config-commons-ui: workspace:*
       eslint-import-resolver-webpack: ^0.13.2
@@ -104,6 +105,7 @@ importers:
       "@nivo/waffle": 0.80.0_6zomopewppbkd5eeu2nbbcio3i
       "@payloadcms/plugin-cloud-storage": 1.0.12_24qdcna5fw7yx55xiuoojdjmn4
       "@payloadcms/plugin-seo": 1.0.9_payload@1.2.5+react@18.2.0
+      dotenv: 16.0.3
       express: 4.18.2
       leaflet: 1.9.3
       nanoid: 4.0.0
@@ -13802,6 +13804,14 @@ packages:
       }
     engines: { node: ">=10" }
     dev: true
+
+  /dotenv/16.0.3:
+    resolution:
+      {
+        integrity: sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==,
+      }
+    engines: { node: ">=12" }
+    dev: false
 
   /dotenv/8.6.0:
     resolution:

--- a/turbo.json
+++ b/turbo.json
@@ -12,6 +12,7 @@
       "env": [
         "MONGO_URL",
         "NEXT_BUILD",
+        "NEXT_MANUAL_SIG_HANDLE",
         "NEXT_PUBLIC_APP_URL",
         "NEXT_PUBLIC_DEFAULT_LOCALE",
         "NEXT_PUBLIC_IMAGE_DOMAINS",


### PR DESCRIPTION
## Description

`payload build` doesn't start `server.js` and hence env vars are not loaded. We should provide defaults for those env vars that are needed by the build script. This PR:
 - [x] adds default for `PAYLOAD_PUBLIC_LOCALES`,
 - [x] uses `dotenv` to load all env before Payload's `buildConfig`, and
 - [x] switches to SSR instead of SSG for pages since payload local API seem to fail to connect (Needs to dig deeper)

This PR also introduces first pass `Dockerfile.charterafrica` to be used to deploy `apps/charterafrica`.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
