### PR TITLE
Close charterafrica mobile drawer after click

### DIFF
--- a/apps/charterafrica/src/components/LanguageButton/LanguageButton.js
+++ b/apps/charterafrica/src/components/LanguageButton/LanguageButton.js
@@ -15,6 +15,7 @@ const LanguageButton = React.forwardRef(function LanguageButton(props, ref) {
   const { locale: currentLocale } = router;
   const handleClick = (e) => {
     e.preventDefault();
+    e.stopPropagation();
 
     setOpen((prevOpen) => !prevOpen);
   };

--- a/apps/charterafrica/src/components/MobileNavBar/MobileNavBar.js
+++ b/apps/charterafrica/src/components/MobileNavBar/MobileNavBar.js
@@ -43,6 +43,7 @@ const MobileNavBar = React.forwardRef(function MobileNavBar(props, ref) {
         open={open}
         onClose={handleClose}
         PaperProps={{
+          onClick: handleClick,
           square: true,
           sx: { overflowY: { xs: "scroll", sm: "visible" } },
         }}

--- a/apps/charterafrica/src/components/NavBarDropdown/NavBarDropdown.js
+++ b/apps/charterafrica/src/components/NavBarDropdown/NavBarDropdown.js
@@ -16,6 +16,7 @@ const NavBarDropdown = React.forwardRef(function NavBarDropdown(props, ref) {
   const anchorRef = React.useRef(null);
   const handleClickArrow = (e) => {
     e.preventDefault();
+    e.stopPropagation();
     setOpen((prevOpen) => !prevOpen);
   };
   // TODO(kilemensi): Since we current don't have any of the child pages, we


### PR DESCRIPTION
## Description

Mobile navigation Drawer remains open after a user has selected new destination. This PR ensures the Drawer is closed after every selection.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code


