### PR TITLE
Handle undefined CSRF and CORS

### DIFF
--- a/apps/charterafrica/payload.config.ts
+++ b/apps/charterafrica/payload.config.ts
@@ -38,11 +38,11 @@ const appURL = process.env.PAYLOAD_PUBLIC_APP_URL;
 
 const cors = process?.env?.PAYLOAD_CORS?.split(",")
   ?.map((d) => d.trim())
-  ?.filter(Boolean);
+  ?.filter(Boolean) ?? [];
 
 const csrf = process?.env?.PAYLOAD_CSRF?.split(",")
   ?.map((d) => d.trim())
-  ?.filter(Boolean);
+  ?.filter(Boolean) ?? [];
 
 const adapter = s3Adapter({
   config: {


### PR DESCRIPTION
This PR fixes server crashing when `PAYLOAD_CSRF` is not provided in environment variables
