### PR TITLE
Fix collections

### DIFF
--- a/apps/charterafrica/src/components/Grantees/GranteeCard.js
+++ b/apps/charterafrica/src/components/Grantees/GranteeCard.js
@@ -26,6 +26,16 @@ const GranteeCard = React.forwardRef(function GranteeCard(props, ref) {
     variant,
   };
 
+  let ActionArea = Box;
+  let ActionAreaProps = { sx: { p: 2.5 } };
+  if (href?.length) {
+    ActionArea = StyledActionArea;
+    ActionAreaProps = {
+      ...ActionAreaProps,
+      component: Link,
+      href,
+    };
+  }
   return (
     <Card
       elevation={elevation}
@@ -34,9 +44,16 @@ const GranteeCard = React.forwardRef(function GranteeCard(props, ref) {
       ownerState={ownerState}
       variant={variant}
     >
-      <StyledActionArea component={href ? Link : undefined} href={href}>
-        <CardMedia image={image.url} sx={{ height: 264 }} />
-        <CardContent>
+      <ActionArea {...ActionAreaProps}>
+        <CardMedia
+          image={image.url}
+          sx={{
+            backgroundOrigin: "content-box",
+            backgroundSize: "contain",
+            height: { sm: 243, md: 264 },
+          }}
+        />
+        <CardContent sx={{ p: 0 }}>
           <LineClampedRichTypography
             color="neutral.dark"
             html={false}
@@ -59,18 +76,27 @@ const GranteeCard = React.forwardRef(function GranteeCard(props, ref) {
             })}
             lineClamp={3}
           />
-          <Box sx={{ height: 94, overflow: "hidden", mt: 1.25 }}>
-            {tags?.map((tag, i) => {
-              return (
+          {tags?.length > 0 ? (
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "column",
+                height: 74,
+                mt: 2.5,
+                overflow: "hidden",
+              }}
+            >
+              {tags.slice(0, 2).map((tag, i) => (
                 <Button
                   component="div"
                   key={tag.id}
                   sx={{
-                    mt: 1.25,
-                    mr: 1.25,
-                    textTransform: "uppercase",
-                    fontSize: 10,
                     color: "neutral.dark",
+                    typography: "footerCap",
+                    width: "fit-content",
+                    ":last-of-type": {
+                      mt: 1.25,
+                    },
                   }}
                   size="small"
                   variant="contained"
@@ -78,11 +104,11 @@ const GranteeCard = React.forwardRef(function GranteeCard(props, ref) {
                 >
                   {tag.name}
                 </Button>
-              );
-            })}
-          </Box>
+              ))}
+            </Box>
+          ) : null}
         </CardContent>
-      </StyledActionArea>
+      </ActionArea>
     </Card>
   );
 });

--- a/apps/charterafrica/src/components/Grantees/Grantees.snap.js
+++ b/apps/charterafrica/src/components/Grantees/Grantees.snap.js
@@ -22,17 +22,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -49,17 +47,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -67,10 +65,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -79,17 +74,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -106,17 +99,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -124,10 +117,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -136,17 +126,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -163,17 +151,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -181,10 +169,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -193,17 +178,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -220,17 +203,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -238,10 +221,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -250,17 +230,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -277,17 +255,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -295,10 +273,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -307,17 +282,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -334,17 +307,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -352,10 +325,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -364,17 +334,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -391,17 +359,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -409,10 +377,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -421,17 +386,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -448,17 +411,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -466,10 +429,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -478,17 +438,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -505,17 +463,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -523,10 +481,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -535,17 +490,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -562,17 +515,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -580,10 +533,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -592,17 +542,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -619,17 +567,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -637,10 +585,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -649,17 +594,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -676,17 +619,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -694,10 +637,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -706,17 +646,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -733,17 +671,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -751,10 +689,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -763,17 +698,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -790,17 +723,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -808,10 +741,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -820,17 +750,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -847,17 +775,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -865,10 +793,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -877,17 +802,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -904,17 +827,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -922,10 +845,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -934,17 +854,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -961,17 +879,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -979,10 +897,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -991,17 +906,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1018,17 +931,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1036,10 +949,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1048,17 +958,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1075,17 +983,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1093,10 +1001,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1105,17 +1010,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1132,17 +1035,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1150,10 +1053,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1162,17 +1062,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1189,17 +1087,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1207,10 +1105,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1219,17 +1114,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1246,17 +1139,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1264,10 +1157,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1276,17 +1166,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1303,17 +1191,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1321,10 +1209,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1333,17 +1218,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1360,17 +1243,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1378,10 +1261,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1390,17 +1270,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1417,17 +1295,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1435,10 +1313,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1447,17 +1322,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1474,17 +1347,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1492,10 +1365,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1504,17 +1374,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1531,17 +1399,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1549,10 +1417,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1561,17 +1426,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1588,17 +1451,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1606,10 +1469,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1618,17 +1478,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1645,17 +1503,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1663,10 +1521,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
         <div
@@ -1675,17 +1530,15 @@ exports[`<Grantees /> renders unchanged 1`] = `
           <div
             class="MuiPaper-root MuiPaper-outlined MuiPaper-rounded MuiCard-root css-1kskzdz-MuiPaper-root-MuiCard-root"
           >
-            <button
-              class="MuiButtonBase-root MuiCardActionArea-root css-1jz6i76-MuiButtonBase-root-MuiCardActionArea-root"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiBox-root css-1ruxp1v"
             >
               <div
-                class="MuiCardMedia-root css-ii8qym-MuiCardMedia-root"
+                class="MuiCardMedia-root css-yvjiy-MuiCardMedia-root"
                 role="img"
               />
               <div
-                class="MuiCardContent-root css-46bh2p-MuiCardContent-root"
+                class="MuiCardContent-root css-1i9wt8r-MuiCardContent-root"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5 css-1nd70j-MuiTypography-root"
@@ -1702,17 +1555,17 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </p>
                 </div>
                 <div
-                  class="MuiBox-root css-etdqi7"
+                  class="MuiBox-root css-dki445"
                 >
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-1sn1gwj-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedSuccess MuiButton-sizeSmall MuiButton-containedSizeSmall css-fzzpj0-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
                     Constitutional changes of government
                   </div>
                   <div
-                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-1ghnvif-MuiButtonBase-root-MuiButton-root"
+                    class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-root MuiButton-contained MuiButton-containedError MuiButton-sizeSmall MuiButton-containedSizeSmall css-11lh5qy-MuiButtonBase-root-MuiButton-root"
                     role="button"
                     tabindex="0"
                   >
@@ -1720,10 +1573,7 @@ exports[`<Grantees /> renders unchanged 1`] = `
                   </div>
                 </div>
               </div>
-              <span
-                class="MuiCardActionArea-focusHighlight css-1v2exvi-MuiCardActionArea-focusHighlight"
-              />
-            </button>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/charterafrica/src/payload/fields/content.js
+++ b/apps/charterafrica/src/payload/fields/content.js
@@ -10,6 +10,7 @@ const content = (overrides) =>
       name: "content",
       type: "blocks",
       blocks: [RichText, MediaBlock, ExternalEmbed],
+      localized: true,
     },
     overrides
   );

--- a/apps/charterafrica/src/theme/index.js
+++ b/apps/charterafrica/src/theme/index.js
@@ -107,6 +107,9 @@ const theme = createTheme({
     body2: undefined,
     caption: initializeTypographyVariant(12, 14),
     footer: initializeTypographyVariant(10, 12),
+    footerCap: initializeTypographyVariant(10, 12, 600, undefined, {
+      textTransform: "uppercase",
+    }),
     overline: undefined,
     number: initializeTypographyVariant(72, 90, 900, PROMPT_FONT_FAMILY),
     numberSmall: initializeTypographyVariant(42, 42, 700, PROMPT_FONT_FAMILY),
@@ -147,6 +150,7 @@ const theme = createTheme({
           caption: "span",
           captionCap: "span",
           footer: "span",
+          footerCap: "span",
           number: "span",
           numberSmall: "span",
         },


### PR DESCRIPTION
## Description

 - [x] Enable content field localization (see below), and
 - [x] Update GranteeCard to match designs.

On content field, setting localized: true in payload config is not enough since we already have data in Mongo DB. We need to also migrate the data to match what Payload expect for a localised field.

We need to transform data from,
```json
  content: [{
    "richTextBlockFields": {
      "content": [
```
to this:
```json
  content: {
    "en": [{
      "richTextBlockFields": {
        "content": [
```
We can do that via collection.updateMany
```js
db.collection.updateMany(
  {
    "content.en": {
      $exists: false
    }    
  },
  [
    {
      $set: {
        content: {
          $mergeObjects: [
            {},
            {
              en: "$content"
            }
          ]
        }
      }
    }
  ]
)
```
Where `collection` is: `events`, `fellowships`, `grantees`, `grants`, `news` and `researches`.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/224988395-662bce51-b429-4f8c-9fc2-e21eee5d5d5d.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

