### PR TITLE
Enable Explainers title show/hide toggle

### DIFF
--- a/apps/charterafrica/src/components/Explainers/Explainer.js
+++ b/apps/charterafrica/src/components/Explainers/Explainer.js
@@ -7,7 +7,7 @@ import React from "react";
 import RichText from "@/charterafrica/components/RichText";
 
 const Explainer = React.forwardRef(function Explainer(props, ref) {
-  const { ImageProps, description, image, sx, title } = props;
+  const { ImageProps, description, image, showTitle, sx, title } = props;
 
   return (
     <Stack sx={sx} ref={ref}>
@@ -23,14 +23,16 @@ const Explainer = React.forwardRef(function Explainer(props, ref) {
           style: { width: "100%", height: "auto", ...ImageProps?.style },
         }}
       />
-      <RichTypography
-        color="neutral.dark"
-        typography={{ md: "h2" }}
-        variant="h3SmallSemiBold"
-        mt={3}
-      >
-        {title}
-      </RichTypography>
+      {showTitle ? (
+        <RichTypography
+          color="neutral.dark"
+          typography={{ md: "h2" }}
+          variant="h3SmallSemiBold"
+          mt={3}
+        >
+          {title}
+        </RichTypography>
+      ) : null}
       <RichText
         color="neutral.dark"
         elements={description}

--- a/apps/charterafrica/src/components/Explainers/Explainers.snap.js
+++ b/apps/charterafrica/src/components/Explainers/Explainers.snap.js
@@ -32,10 +32,37 @@ exports[`<Explainers /> renders unchanged 1`] = `
           />
         </figure>
         <div
-          class="MuiTypography-root MuiTypography-h3SmallSemiBold css-zyjgo7-MuiTypography-root"
+          class="MuiBox-root css-0"
         >
-          Event title going on two or even three lines
+          <p
+            class="MuiTypography-root MuiTypography-p2 css-dk4osf-MuiTypography-root"
+          >
+            Lorem ipsum dolor sit amet consectetur adipiscing elit tempus nibh cursus, urna porta sagittis non eget taciti nunc sed felis dui, praesent ullamcorper facilisi euismod ut in platea laoreet integer. Lorem ipsum dolor sit amet consectetur Lorem ipsum dolor sit amet consectetur adipiscing elit tempus nibh cursus, urna porta sagittis non eget taciti nunc sed felis dui, praesent ullamcorper facilisi euismod ut in platea laoreet integer. Lorem ipsum dolor sit amet consectetur 
+          </p>
         </div>
+      </div>
+      <hr
+        class="MuiDivider-root MuiDivider-fullWidth css-1i2odet-MuiDivider-root"
+      />
+      <div
+        class="css-nen11g-MuiStack-root"
+      >
+        <figure
+          class="MuiBox-root css-db5opy"
+        >
+          <img
+            alt="Event title going on two or even three lines"
+            class="css-g98gbd"
+            data-nimg="1"
+            decoding="async"
+            height="0"
+            loading="lazy"
+            src="/_next/image?url=https%3A%2F%2Fuser-images.githubusercontent.com%2F39160236%2F214778112-7aefbe8f-11f2-423f-b6c9-a284feaf9b33.png&w=16&q=75"
+            srcset="/_next/image?url=https%3A%2F%2Fuser-images.githubusercontent.com%2F39160236%2F214778112-7aefbe8f-11f2-423f-b6c9-a284feaf9b33.png&w=16&q=75 1x"
+            style="color: transparent; width: 100%; height: auto;"
+            width="0"
+          />
+        </figure>
         <div
           class="MuiBox-root css-0"
         >
@@ -69,11 +96,6 @@ exports[`<Explainers /> renders unchanged 1`] = `
           />
         </figure>
         <div
-          class="MuiTypography-root MuiTypography-h3SmallSemiBold css-zyjgo7-MuiTypography-root"
-        >
-          Event title going on two or even three lines
-        </div>
-        <div
           class="MuiBox-root css-0"
         >
           <p
@@ -106,11 +128,6 @@ exports[`<Explainers /> renders unchanged 1`] = `
           />
         </figure>
         <div
-          class="MuiTypography-root MuiTypography-h3SmallSemiBold css-zyjgo7-MuiTypography-root"
-        >
-          Event title going on two or even three lines
-        </div>
-        <div
           class="MuiBox-root css-0"
         >
           <p
@@ -142,48 +159,6 @@ exports[`<Explainers /> renders unchanged 1`] = `
             width="0"
           />
         </figure>
-        <div
-          class="MuiTypography-root MuiTypography-h3SmallSemiBold css-zyjgo7-MuiTypography-root"
-        >
-          Event title going on two or even three lines
-        </div>
-        <div
-          class="MuiBox-root css-0"
-        >
-          <p
-            class="MuiTypography-root MuiTypography-p2 css-dk4osf-MuiTypography-root"
-          >
-            Lorem ipsum dolor sit amet consectetur adipiscing elit tempus nibh cursus, urna porta sagittis non eget taciti nunc sed felis dui, praesent ullamcorper facilisi euismod ut in platea laoreet integer. Lorem ipsum dolor sit amet consectetur Lorem ipsum dolor sit amet consectetur adipiscing elit tempus nibh cursus, urna porta sagittis non eget taciti nunc sed felis dui, praesent ullamcorper facilisi euismod ut in platea laoreet integer. Lorem ipsum dolor sit amet consectetur 
-          </p>
-        </div>
-      </div>
-      <hr
-        class="MuiDivider-root MuiDivider-fullWidth css-1i2odet-MuiDivider-root"
-      />
-      <div
-        class="css-nen11g-MuiStack-root"
-      >
-        <figure
-          class="MuiBox-root css-db5opy"
-        >
-          <img
-            alt="Event title going on two or even three lines"
-            class="css-g98gbd"
-            data-nimg="1"
-            decoding="async"
-            height="0"
-            loading="lazy"
-            src="/_next/image?url=https%3A%2F%2Fuser-images.githubusercontent.com%2F39160236%2F214778112-7aefbe8f-11f2-423f-b6c9-a284feaf9b33.png&w=16&q=75"
-            srcset="/_next/image?url=https%3A%2F%2Fuser-images.githubusercontent.com%2F39160236%2F214778112-7aefbe8f-11f2-423f-b6c9-a284feaf9b33.png&w=16&q=75 1x"
-            style="color: transparent; width: 100%; height: auto;"
-            width="0"
-          />
-        </figure>
-        <div
-          class="MuiTypography-root MuiTypography-h3SmallSemiBold css-zyjgo7-MuiTypography-root"
-        >
-          Event title going on two or even three lines
-        </div>
         <div
           class="MuiBox-root css-0"
         >

--- a/apps/charterafrica/src/payload/collections/Explainers.js
+++ b/apps/charterafrica/src/payload/collections/Explainers.js
@@ -12,7 +12,11 @@ const Explainers = {
   fields: [
     {
       type: "collapsible",
-      label: "Title",
+      label: {
+        en: "Title",
+        fr: "Titre",
+        pt: "Título",
+      },
       fields: [
         {
           name: "title",

--- a/apps/charterafrica/src/payload/collections/Explainers.js
+++ b/apps/charterafrica/src/payload/collections/Explainers.js
@@ -11,14 +11,30 @@ const Explainers = {
   },
   fields: [
     {
-      name: "title",
-      label: {
-        en: "Title",
-        fr: "Titre",
-        pt: "Título",
-      },
-      type: "text",
-      localized: true,
+      type: "collapsible",
+      label: "Title",
+      fields: [
+        {
+          name: "title",
+          label: {
+            en: "Title",
+            fr: "Titre",
+            pt: "Título",
+          },
+          type: "text",
+          required: true,
+          localized: true,
+        },
+        {
+          name: "showTitle",
+          label: {
+            en: "Show on the website",
+          },
+          type: "checkbox",
+          defaultValue: false,
+          required: true,
+        },
+      ],
     },
     richText({
       name: "description",


### PR DESCRIPTION
## Description

This PR enables title show/hide toggle on explainers. The reason being: without title, it's hard to know which explainer is which & hence explainers must include titles. But content editors still need to decide if any given title should appear on the front-end.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![Screenshot 2023-03-17 at 11-01-36 charter AFRICA](https://user-images.githubusercontent.com/1779590/225847452-90f9e99f-a100-4481-afc0-e268ff1487c1.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

