### PR TITLE
Fix charterafrica articles pagination

### DIFF
--- a/apps/charterafrica/contrib/dokku/Dockerfile
+++ b/apps/charterafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/charterafrica-ui:0.0.38
+FROM codeforafrica/charterafrica-ui:0.0.39

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charterafrica",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the official code for https://charter.africa site",

--- a/apps/charterafrica/src/lib/data/common/index.js
+++ b/apps/charterafrica/src/lib/data/common/index.js
@@ -210,10 +210,10 @@ export async function getArticles(page, api, context) {
   const { docs, totalPages } = await api.getCollection(collection, {
     locale,
     sort,
+    page: pageNumber,
     limit: pageSize,
     where: {
       ...query,
-      page: pageNumber,
       _status: { equals: "published" },
     },
   });


### PR DESCRIPTION
## Description

`page`, was included as part of `where` clause instead of main `option`. This PR fixes [that](https://payloadcms.com/docs/local-api/overview#collections).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

