### PR TITLE
Fix charterafrica news/research page switch

### DIFF
--- a/apps/charterafrica/contrib/dokku/Dockerfile
+++ b/apps/charterafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/charterafrica-ui:0.0.41
+FROM codeforafrica/charterafrica-ui:0.0.42

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charterafrica",
-  "version": "0.0.41",
+  "version": "0.0.42",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the official code for https://charter.africa site",

--- a/apps/charterafrica/src/lib/data/common/index.js
+++ b/apps/charterafrica/src/lib/data/common/index.js
@@ -523,8 +523,7 @@ async function processPageArticles(page, api, context) {
     },
     slug,
     title,
-    // since there can be 1 articles block per page
-    id: "articles",
+    id: `articles-${slug}`,
   };
   blocks.push(articlesBlock);
 


### PR DESCRIPTION
## Description

When a user paginates while on news page, switching directly to research page doesn't seem to reset the page back to 1. This is because the `Articles` component used in both of these pages, uses `articles` as `id` which in turn is used as `key` in `[...slug].page` page.

This PR ensures these two pages uses two separate ids; `articles-news` for news and `articles-research` for research forcing React to completely re-render the component and hence forgetting the component state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

