### PR TITLE
Fix Video description

### DIFF
--- a/apps/charterafrica/src/lib/data/common/processPageConsultation.js
+++ b/apps/charterafrica/src/lib/data/common/processPageConsultation.js
@@ -12,11 +12,15 @@ export async function getVideosFromPlaylist(playlistId, options) {
 
   const videosFromApi = await fetchPlaylistItems(playlistId, options);
   const items =
-    videosFromApi.items?.map(({ snippet, ...restArgs }) => ({
-      ...snippet,
-      ...snippet?.resourceId,
-      ...restArgs,
-    })) || [];
+    videosFromApi.items?.map(({ snippet, ...restArgs }) => {
+      const { description } = snippet;
+      return {
+        ...snippet,
+        ...snippet?.resourceId,
+        ...restArgs,
+        description: description?.replace(/\r?\n/g, "<br />") || null,
+      };
+    }) || [];
   return items;
 }
 


### PR DESCRIPTION
## Description

YouTube returns video description as text with line-breaks for formatting. We need to manually convert those to <br /> to display properly on the web page. This PR addresses that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://user-images.githubusercontent.com/1779590/230362631-a3b6a837-9446-45e8-a6ee-f962e86d3f5f.jpg)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
