### PR TITLE
Remove ellipsis on Hero Slider content

### DIFF
--- a/apps/charterafrica/src/components/Hero/Hero.snap.js
+++ b/apps/charterafrica/src/components/Hero/Hero.snap.js
@@ -40,7 +40,7 @@ exports[`<Hero /> renders unchanged 1`] = `
                   </h1>
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-p1 css-1ht5usx-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-p1 css-1p97i67-MuiTypography-root"
                 >
                   Easy to use resources for democracy activists
                 </div>

--- a/apps/charterafrica/src/components/Hero/Hero.snap.js
+++ b/apps/charterafrica/src/components/Hero/Hero.snap.js
@@ -40,7 +40,7 @@ exports[`<Hero /> renders unchanged 1`] = `
                   </h1>
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-p1 css-12fpwxu-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-p1 css-1ht5usx-MuiTypography-root"
                 >
                   Easy to use resources for democracy activists
                 </div>

--- a/apps/charterafrica/src/components/Hero/Hero.snap.js
+++ b/apps/charterafrica/src/components/Hero/Hero.snap.js
@@ -40,7 +40,7 @@ exports[`<Hero /> renders unchanged 1`] = `
                   </h1>
                 </div>
                 <div
-                  class="MuiTypography-root MuiTypography-p1 css-1p97i67-MuiTypography-root"
+                  class="MuiTypography-root MuiTypography-p1 css-5wjfwk-MuiTypography-root"
                 >
                   Easy to use resources for democracy activists
                 </div>

--- a/apps/charterafrica/src/components/Hero/Slide.js
+++ b/apps/charterafrica/src/components/Hero/Slide.js
@@ -74,9 +74,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
             sx={(t) => ({
               color: subheading?.color,
               minHeight: `calc(${t.typography.p1.fontSize}px*${t.typography.p1.lineHeight}*2)`,
-              [t.breakpoints.up("sm")]: {
-                minHeight: `calc(${t.typography.p1.fontSize}px*${t.typography.p1.lineHeight})`,
-              },
               [t.breakpoints.up("md")]: {
                 typography: "subheading",
                 minHeight: `calc(${t.typography.subheading.fontSize}px*${t.typography.subheading.lineHeight}*2)`,

--- a/apps/charterafrica/src/components/Hero/Slide.js
+++ b/apps/charterafrica/src/components/Hero/Slide.js
@@ -66,7 +66,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
             })}
           />
           <LineClampedRichTypography
-            lineClamp={{ xs: "2", sm: "1" }}
+            lineClamp="2"
             mt="30px"
             textAlign="center"
             variant="p1"
@@ -81,7 +81,6 @@ const Slide = React.forwardRef(function Slide(props, ref) {
                 typography: "subheading",
                 minHeight: `calc(${t.typography.subheading.fontSize}px*${t.typography.subheading.lineHeight}*2)`,
               },
-              "-webkit-line-clamp": "unset !important",
             })}
           >
             {subheading?.content || subheading}

--- a/apps/charterafrica/src/components/Hero/Slide.js
+++ b/apps/charterafrica/src/components/Hero/Slide.js
@@ -81,6 +81,7 @@ const Slide = React.forwardRef(function Slide(props, ref) {
                 typography: "subheading",
                 minHeight: `calc(${t.typography.subheading.fontSize}px*${t.typography.subheading.lineHeight}*2)`,
               },
+              "-webkit-line-clamp": "unset !important",
             })}
           >
             {subheading?.content || subheading}


### PR DESCRIPTION
## Description

This PR removes the ellipsis on hero content caused by `webkit-line-clamp`

Fixes #

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
![image](https://github.com/CodeForAfrica/ui/assets/43873157/692fa534-4318-42d4-995f-5710670f2780)
![image](https://github.com/CodeForAfrica/ui/assets/43873157/c3c138df-73bc-4a04-a6e8-7324073c8170)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
