### PR TITLE
@/charterafrica reuse page

### DIFF
--- a/apps/charterafrica/src/lib/data/common/index.js
+++ b/apps/charterafrica/src/lib/data/common/index.js
@@ -70,12 +70,12 @@ async function processGlobalBlockFocalCountries(block) {
 }
 
 async function processGlobalBlockHelpdesk(block) {
-  const { description, image, link, slug, title } = block || {};
+  const { description, id, image, link, slug, title } = block || {};
   if (!title?.length) {
     return null;
   }
 
-  const helpdesk = { slug, title };
+  const helpdesk = { id, slug, title };
   if (description?.length) {
     helpdesk.description = description;
   }

--- a/apps/charterafrica/src/lib/data/common/processPageExplainers.js
+++ b/apps/charterafrica/src/lib/data/common/processPageExplainers.js
@@ -4,9 +4,10 @@ async function processPageExplainers(page, api, context) {
   const { title, blocks } = page;
   if (explainers?.length) {
     blocks.push({
+      id: page.id,
+      explainers,
       slug: "explainers",
       title,
-      explainers,
     });
   }
 

--- a/apps/charterafrica/src/pages/[...slugs].page.js
+++ b/apps/charterafrica/src/pages/[...slugs].page.js
@@ -20,6 +20,7 @@ import Helpdesk from "@/charterafrica/components/Helpdesk";
 import HelpdeskPageContent from "@/charterafrica/components/HelpdeskPageContent";
 import Hero from "@/charterafrica/components/Hero";
 import Impressum from "@/charterafrica/components/Impressum";
+import Infographic from "@/charterafrica/components/Infographic";
 import LongForm from "@/charterafrica/components/LongForm";
 import Mooc from "@/charterafrica/components/Mooc";
 import Opportunity from "@/charterafrica/components/Opportunity";
@@ -39,6 +40,7 @@ import Tools from "@/charterafrica/components/Tools";
 import { getPageServerSideProps } from "@/charterafrica/lib/data";
 
 const componentsBySlugs = {
+  "aga-infographic": Infographic,
   datasets: Datasets,
   dataset: Dataset,
   documents: Documents,

--- a/apps/charterafrica/src/pages/index.page.js
+++ b/apps/charterafrica/src/pages/index.page.js
@@ -1,40 +1,10 @@
-import React from "react";
-
-import Ecosystem from "@/charterafrica/components/Ecosystem";
-import FocalCountries from "@/charterafrica/components/FocalCountries";
-import Helpdesk from "@/charterafrica/components/Helpdesk";
-import Hero from "@/charterafrica/components/Hero";
-import Infographic from "@/charterafrica/components/Infographic";
-import Mooc from "@/charterafrica/components/Mooc";
-import Partners from "@/charterafrica/components/Partners";
-import Resources from "@/charterafrica/components/Resources";
-import Spotlight from "@/charterafrica/components/Spotlight";
-import { getPageServerSideProps } from "@/charterafrica/lib/data";
-
-const componentsBySlugs = {
-  ecosystem: Ecosystem,
-  "focal-countries": FocalCountries,
-  helpdesk: Helpdesk,
-  hero: Hero,
-  "aga-infographic": Infographic,
-  mooc: Mooc,
-  "our-partners": Partners,
-  "our-resources": Resources,
-  spotlight: Spotlight,
-};
-
-function Index({ blocks }) {
-  return blocks?.map((block) => {
-    const Component = componentsBySlugs[block?.slug];
-    if (!Component) {
-      return null;
-    }
-    return <Component {...block} key={block.id} />;
-  });
-}
+import Page, {
+  getServerSideProps as sharedGetServerSideProps,
+} from "./[...slugs].page";
 
 export async function getServerSideProps(context) {
-  return getPageServerSideProps(context);
+  const func = sharedGetServerSideProps.bind(this);
+  return func(context);
 }
 
-export default Index;
+export default Page;


### PR DESCRIPTION
## Description

There is no need for `/index.page.js` to duplicate what `/[...slugs].page.js` is doing. This PR imports functionality from `...slugs` page into `index` page and reuse it.

## Type of change
- [x] Chore

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
