### PR TITLE
@/charterafrica Reduce navigation data

### DIFF
--- a/apps/charterafrica/src/components/NavBarDropdown/NavBarDropdown.js
+++ b/apps/charterafrica/src/components/NavBarDropdown/NavBarDropdown.js
@@ -19,9 +19,6 @@ const NavBarDropdown = React.forwardRef(function NavBarDropdown(props, ref) {
     e.stopPropagation();
     setOpen((prevOpen) => !prevOpen);
   };
-  // TODO(kilemensi): Since we current don't have any of the child pages, we
-  //                  have to manually hide the popup.
-  //                  SHOULD BE REMOVED ONCE CHILD PAGES ARE IMPLEMENTED.
   const handleClickMenuItem = () => {
     setOpen(false);
   };

--- a/apps/charterafrica/src/lib/data/common/index.js
+++ b/apps/charterafrica/src/lib/data/common/index.js
@@ -36,7 +36,19 @@ export async function getGlobalProps({ locale, defaultLocale }, api) {
       href: "/",
       priority: true,
     },
-    menus: menus ?? null,
+    menus:
+      menus?.map((originalMenu) => {
+        const { doc, ...menu } = originalMenu;
+        // Remove pages (doc) from menu and it's children
+        // This can also be done via afterRead global hook on navigation block
+        // but it may interfere with CMS functionality
+        if (menu.children) {
+          menu.children =
+            menu.children?.map(({ doc: _, ...other }) => ({ ...other })) ??
+            null;
+        }
+        return menu;
+      }) ?? null,
   };
   const footer = await api.findGlobal("footer", {
     locale,


### PR DESCRIPTION
## Description

We're currently returning full page data for all internal links in navigation. This is unnecessary and sometimes leads to errors when page content (e.g. blocks) are missing or edited.

We only need a page to compute `href` and once that's done, we should no longer need any other page data in menu. This PR removes `doc` on every menu item.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
