### PR TITLE
Fixes an issue with ecosystem globals not rendering on initial database

### DIFF
--- a/apps/charterafrica/src/payload/fields/ecosystem/airtableBaseSelect.js
+++ b/apps/charterafrica/src/payload/fields/ecosystem/airtableBaseSelect.js
@@ -31,8 +31,10 @@ const validateBaseSelect = async (value, { hasMany, required, t }) => {
   const valid = select(value, { hasMany, options, required, t });
   if (valid) {
     const link = getTablesUrl(value);
-    const { tables } = await fetchJson.get(link);
-    schema.tables = tables;
+    if (link) {
+      const { tables } = await fetchJson.get(link);
+      schema.tables = tables;
+    }
   }
   return valid;
 };

--- a/apps/charterafrica/src/payload/globals/Ecosystem.js
+++ b/apps/charterafrica/src/payload/globals/Ecosystem.js
@@ -11,7 +11,6 @@ const Ecosystem = {
   label: { en: "Ecosystem", fr: "Écosystème", pt: "Ecossistema" },
   access: {
     read: () => true,
-    update: () => true,
   },
   fields: [
     {

--- a/apps/charterafrica/src/payload/globals/Ecosystem.js
+++ b/apps/charterafrica/src/payload/globals/Ecosystem.js
@@ -11,6 +11,7 @@ const Ecosystem = {
   label: { en: "Ecosystem", fr: "Écosystème", pt: "Ecossistema" },
   access: {
     read: () => true,
+    update: () => true,
   },
   fields: [
     {


### PR DESCRIPTION
## Description
Ecosystem globals is blank on deve environment.
This happens on an empty database
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
