### PR TITLE
catch exception when globals not set

### DIFF
--- a/apps/charterafrica/src/lib/ecosystem/index.js
+++ b/apps/charterafrica/src/lib/ecosystem/index.js
@@ -12,8 +12,25 @@ import {
 import api from "@/charterafrica/lib/payload";
 import { ECOSYSTEM_GLOBAL } from "@/charterafrica/payload/utils/collections";
 
+function checkConfig(config) {
+  const configTableNames = [
+    "toolTableId",
+    "contributorTableId",
+    "organisationTableId",
+    "partnersTableId",
+    "socialMediaTableId",
+  ];
+  return configTableNames.reduce((acc, current) => {
+    return acc && !!config?.schema?.[current];
+  }, true);
+}
+
 export async function updateList() {
   const config = await api.findGlobal(ECOSYSTEM_GLOBAL, {});
+  if (!checkConfig(config)) {
+    Sentry.captureException("Process not executed. Ecosystem Globals not set");
+    return { message: "Globals not set" };
+  }
   const execute = async () => {
     Sentry.captureEvent({
       message: `Update Ecosystem List process started at ${new Date().toString()}`,

--- a/apps/charterafrica/src/lib/ecosystem/index.js
+++ b/apps/charterafrica/src/lib/ecosystem/index.js
@@ -13,16 +13,15 @@ import api from "@/charterafrica/lib/payload";
 import { ECOSYSTEM_GLOBAL } from "@/charterafrica/payload/utils/collections";
 
 function checkConfig(config) {
-  const configTableNames = [
+  const requiredTables = [
     "toolTableId",
     "contributorTableId",
     "organisationTableId",
     "partnersTableId",
     "socialMediaTableId",
   ];
-  return configTableNames.reduce((acc, current) => {
-    return acc && !!config?.schema?.[current];
-  }, true);
+  const isPresent = (tableName) => config?.schema?.[tableName];
+  return requiredTables.every(isPresent);
 }
 
 export async function updateList() {

--- a/apps/charterafrica/src/payload/globals/Ecosystem.js
+++ b/apps/charterafrica/src/payload/globals/Ecosystem.js
@@ -11,6 +11,7 @@ const Ecosystem = {
   label: { en: "Ecosystem", fr: "Écosystème", pt: "Ecossistema" },
   access: {
     read: () => true,
+    update: () => true,
   },
   fields: [
     {


### PR DESCRIPTION
## Description
When Ecosystem globals hasn't been set, the server stops and because of tableId fields are undefined forcing database reconnections
Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
