### PR TITLE
Fix charterafrica i18n seo

### DIFF
--- a/apps/charterafrica/src/lib/data/common/index.js
+++ b/apps/charterafrica/src/lib/data/common/index.js
@@ -175,6 +175,7 @@ export async function getPageProps(api, context) {
     api
   );
   const seo = getPageSeoFromMeta(processedPage, settings, {
+    defaultLocale,
     locale,
     locales,
     pathname,

--- a/apps/charterafrica/src/lib/data/seo.js
+++ b/apps/charterafrica/src/lib/data/seo.js
@@ -4,25 +4,33 @@ import site from "@/charterafrica/utils/site";
 
 const siteUrl = new URL(site.environmentUrl).href;
 
-function localeToLanguageAlternative(locale, pathname) {
-  const separator = !pathname || pathname.startsWith("/") ? "" : `/`;
-  const hrefLang = locale;
-  const { href } = new URL(`/${locale}${separator}${pathname}`, siteUrl);
-  return { hrefLang, href };
+function getLanguageAlternates(options) {
+  const { defaultLocale, locale, locales, pathname } = options;
+  if (!(locale && locales?.length)) {
+    return null;
+  }
+
+  const languageAlternateForLocale = (loc) => {
+    const hrefLang = loc;
+    const separator = !pathname || pathname.startsWith("/") ? "" : `/`;
+    // By default, default locale doesn't include prefix
+    let prefix = `/${loc}`;
+    if (loc === defaultLocale) {
+      prefix = "";
+    }
+    const { href } = new URL(`${prefix}${separator}${pathname}`, siteUrl);
+    return { hrefLang, href };
+  };
+  return locales.map(languageAlternateForLocale);
 }
 
 export function getPageSeoFromMeta(page, settings, options = {}) {
-  const { locale, locales, pathname } = options;
+  const { locale, pathname } = options;
   let canonical = null;
   if (pathname) {
     canonical = new URL(pathname, siteUrl).toString();
   }
-  let languageAlternates = null;
-  if (locales?.length) {
-    languageAlternates = locales.map((l) =>
-      localeToLanguageAlternative(l, pathname)
-    );
-  }
+  const languageAlternates = getLanguageAlternates(options);
   const { title: pageTitle, meta: pageMeta } = page;
   const {
     meta: settingsMeta,

--- a/apps/charterafrica/src/pages/_document.page.js
+++ b/apps/charterafrica/src/pages/_document.page.js
@@ -8,7 +8,7 @@ import createEmotionCache from "@/charterafrica/utils/createEmotionCache";
 export default class MyDocument extends Document {
   render() {
     return (
-      <Html lang="en">
+      <Html>
         <Head>
           <link
             rel="preload"


### PR DESCRIPTION
## Description

Current implementation has `lang="en"` hard-coded in html tag preventing search engines differentiating languages. The default locale ("en") also sets `hreflang` starting with `/en` when by default, Next.js doesn't include locale prefix for the default locale.

This PR address both of the above.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

### After
![S1](https://github.com/CodeForAfrica/ui/assets/1779590/73cf77d0-6b2a-4a5a-8d0b-1a3ec3dcb87d)

### Before
![S2](https://github.com/CodeForAfrica/ui/assets/1779590/59a5c19b-1796-473d-9582-a3b39858a51a)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
