### PR TITLE
Upgrade UI to node 18

### DIFF
--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [18]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/charterafrica-deploy-prod.yml
+++ b/.github/workflows/charterafrica-deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [18]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
     strategy:
       matrix:
+        node-version: [18]
         os: [ubuntu-latest]
-        node-version: [16]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/codeforafrica-deploy-prod.yml
+++ b/.github/workflows/codeforafrica-deploy-prod.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [18]
         os: [ubuntu-latest]
     steps:
       - name: Checkout

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16]
+        node-version: [18]
         os: [ubuntu-latest]
     steps:
       - name: Check out code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-alpine as node-alpine
+FROM node:18-alpine as node-alpine
 
 # Always install security updated e.g. https://pythonspeed.com/articles/security-updates-in-docker/
 # Update local cache so that other stages don't need to update cache
@@ -9,7 +9,7 @@ RUN apk update \
 FROM node-alpine as base
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add libc6-compat
+RUN apk add --no-cache libc6-compat
 
 ARG PNPM_VERSION=8.5.0
 

--- a/Dockerfile.charterafrica
+++ b/Dockerfile.charterafrica
@@ -1,4 +1,4 @@
-FROM node:16-alpine as node-alpine
+FROM node:18-alpine as node-alpine
 
 # Always install security updated e.g. https://pythonspeed.com/articles/security-updates-in-docker/
 # Update local cache so that other stages don't need to update cache
@@ -9,7 +9,7 @@ RUN apk update \
 FROM node-alpine as base
 
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add libc6-compat
+RUN apk add --no-cache libc6-compat
 
 ARG PNPM_VERSION=8.5.0
 

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -88,7 +88,7 @@
     "@svgr/webpack": "^6.5.1",
     "@swc/core": "^1.3.56",
     "@types/express": "^4.17.17",
-    "@types/node": "^16.18.25",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.2.5",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -67,7 +67,7 @@
     "@commons-ui/testing-library": "workspace:*",
     "@playwright/test": "^1.33.0",
     "@svgr/webpack": "^6.5.1",
-    "@types/node": "^16.18.25",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.2.5",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/apps/commons-ui-docs/package.json
+++ b/apps/commons-ui-docs/package.json
@@ -53,7 +53,7 @@
     "@storybook/nextjs": "^7.0.8",
     "@storybook/react": "^7.0.8",
     "@storybook/testing-library": "0.0.14-next.2",
-    "@types/node": "^16.18.25",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.2.5",
     "eslint": "^8.39.0",
     "eslint-config-commons-ui": "workspace:*",

--- a/apps/pesayetu/package.json
+++ b/apps/pesayetu/package.json
@@ -46,7 +46,7 @@
     "@babel/preset-react": "^7.18.6",
     "@commons-ui/testing-library": "workspace:*",
     "@playwright/test": "^1.33.0",
-    "@types/node": "^16.18.25",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.2.5",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/apps/promisetracker/package.json
+++ b/apps/promisetracker/package.json
@@ -62,7 +62,7 @@
     "@commons-ui/testing-library": "workspace:*",
     "@playwright/test": "^1.33.0",
     "@svgr/webpack": "^6.2.1",
-    "@types/node": "^16.18.25",
+    "@types/node": "^18.11.9",
     "@types/react": "^18.2.5",
     "babel-jest": "^29.5.0",
     "eslint": "^8.39.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,8 +197,8 @@ importers:
         specifier: ^4.17.17
         version: 4.17.17
       "@types/node":
-        specifier: ^16.18.25
-        version: 16.18.25
+        specifier: ^18.11.9
+        version: 18.11.9
       "@types/react":
         specifier: ^18.2.5
         version: 18.2.5
@@ -222,7 +222,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../../packages/jest-config-commons-ui
@@ -240,7 +240,7 @@ importers:
         version: 18.2.0(react@18.2.0)
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.1(@swc/core@1.3.56)(@types/node@16.18.25)(typescript@4.9.5)
+        version: 10.9.1(@swc/core@1.3.56)(@types/node@18.11.9)(typescript@4.9.5)
       typescript:
         specifier: ^4.9.5
         version: 4.9.5
@@ -351,8 +351,8 @@ importers:
         specifier: ^6.5.1
         version: 6.5.1
       "@types/node":
-        specifier: ^16.18.25
-        version: 16.18.25
+        specifier: ^18.11.9
+        version: 18.11.9
       "@types/react":
         specifier: ^18.2.5
         version: 18.2.5
@@ -376,7 +376,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../../packages/jest-config-commons-ui
@@ -472,8 +472,8 @@ importers:
         specifier: 0.0.14-next.2
         version: 0.0.14-next.2
       "@types/node":
-        specifier: ^16.18.25
-        version: 16.18.25
+        specifier: ^18.11.9
+        version: 18.11.9
       "@types/react":
         specifier: ^18.2.5
         version: 18.2.5
@@ -545,8 +545,8 @@ importers:
         specifier: ^1.33.0
         version: 1.33.0
       "@types/node":
-        specifier: ^16.18.25
-        version: 16.18.25
+        specifier: ^18.11.9
+        version: 18.11.9
       "@types/react":
         specifier: ^18.2.5
         version: 18.2.5
@@ -564,7 +564,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../../packages/jest-config-commons-ui
@@ -699,8 +699,8 @@ importers:
         specifier: ^1.33.0
         version: 1.33.0
       "@types/node":
-        specifier: ^16.18.25
-        version: 16.18.25
+        specifier: ^18.11.9
+        version: 18.11.9
       "@types/react":
         specifier: ^18.2.5
         version: 18.2.5
@@ -724,7 +724,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../../packages/jest-config-commons-ui
@@ -788,7 +788,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../jest-config-commons-ui
@@ -846,7 +846,7 @@ importers:
         version: link:../eslint-config-commons-ui
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../jest-config-commons-ui
@@ -916,7 +916,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-config-commons-ui:
         specifier: workspace:*
         version: link:../jest-config-commons-ui
@@ -1038,7 +1038,7 @@ importers:
         version: 3.0.0
       jest:
         specifier: ^29.5.0
-        version: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+        version: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       prettier:
         specifier: ^2.8.8
         version: 2.8.8
@@ -5353,7 +5353,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       jest-message-util: 29.5.0
       jest-util: 29.5.0
@@ -5377,14 +5377,14 @@ packages:
       "@jest/test-result": 29.5.0
       "@jest/transform": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.8.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.5.0
-      jest-config: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-config: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-haste-map: 29.5.0
       jest-message-util: 29.5.0
       jest-regex-util: 29.4.3
@@ -5414,7 +5414,7 @@ packages:
     dependencies:
       "@jest/fake-timers": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-mock: 29.5.0
 
   /@jest/expect-utils@29.5.0:
@@ -5448,7 +5448,7 @@ packages:
     dependencies:
       "@jest/types": 29.5.0
       "@sinonjs/fake-timers": 10.0.2
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-message-util: 29.5.0
       jest-mock: 29.5.0
       jest-util: 29.5.0
@@ -5486,7 +5486,7 @@ packages:
       "@jest/transform": 29.5.0
       "@jest/types": 29.5.0
       "@jridgewell/trace-mapping": 0.3.18
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       collect-v8-coverage: 1.0.1
       exit: 0.1.2
@@ -5590,7 +5590,7 @@ packages:
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.4
       "@types/istanbul-reports": 3.0.1
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/yargs": 16.0.5
       chalk: 4.1.2
     dev: true
@@ -5605,7 +5605,7 @@ packages:
       "@jest/schemas": 29.4.3
       "@types/istanbul-lib-coverage": 2.0.4
       "@types/istanbul-reports": 3.0.1
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/yargs": 17.0.24
       chalk: 4.1.2
 
@@ -8680,7 +8680,7 @@ packages:
       }
     dependencies:
       "@types/connect": 3.4.35
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/caseless@0.12.2:
@@ -8696,7 +8696,7 @@ packages:
         integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/d3-array@3.0.4:
@@ -8833,7 +8833,7 @@ packages:
         integrity: sha512-fvr49XlCGoUj2Pp730AItckfjat4WNb0lb3kfrLWffd+RLeoGAMsq7UOy04PAPtoL01uKwcp6u8nhzpgpDYr3w==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/qs": 6.9.7
       "@types/range-parser": 1.2.4
       "@types/send": 0.17.1
@@ -8865,7 +8865,7 @@ packages:
       }
     dependencies:
       "@types/minimatch": 5.1.2
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: false
 
   /@types/glob@8.1.0:
@@ -8875,7 +8875,7 @@ packages:
       }
     dependencies:
       "@types/minimatch": 5.1.2
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/graceful-fs@4.1.6:
@@ -8884,7 +8884,7 @@ packages:
         integrity: sha512-Sig0SNORX9fdW+bQuTEovKj3uHcUL6LQKbCrrqb1X7J6/ReAbhCXRAhc+SMejhLELFj2QcyuxmUooZ4bt5ReSw==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/html-minifier-terser@6.1.0:
@@ -8947,7 +8947,7 @@ packages:
         integrity: sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/tough-cookie": 4.0.2
       parse5: 7.1.2
     dev: false
@@ -9026,7 +9026,7 @@ packages:
         integrity: sha512-ETTL1mOEdq/sxUtgtOhKjyB2Irra4cjxksvcMUR5Zr4n+PxVhsCD9WS46oPbHL3et9Zde7CNRr+WUNlcHvsX+w==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       form-data: 3.0.1
     dev: true
 
@@ -9040,6 +9040,13 @@ packages:
     resolution:
       {
         integrity: sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==,
+      }
+    dev: true
+
+  /@types/node@18.11.9:
+    resolution:
+      {
+        integrity: sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==,
       }
 
   /@types/normalize-package-data@2.4.1:
@@ -9147,7 +9154,7 @@ packages:
       }
     dependencies:
       "@types/caseless": 0.12.2
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/tough-cookie": 4.0.2
       form-data: 2.5.1
     dev: false
@@ -9178,7 +9185,7 @@ packages:
       }
     dependencies:
       "@types/mime": 1.3.2
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/serve-static@1.15.1:
@@ -9188,7 +9195,7 @@ packages:
       }
     dependencies:
       "@types/mime": 3.0.1
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /@types/sharp@0.31.1:
@@ -9197,7 +9204,7 @@ packages:
         integrity: sha512-5nWwamN9ZFHXaYEincMSuza8nNfOof8nmO+mcI+Agx1uMUk4/pQnNIcix+9rLPXzKrm1pS34+6WRDbDV0Jn7ag==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: false
 
   /@types/stack-utils@2.0.1:
@@ -9248,7 +9255,7 @@ packages:
         integrity: sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==,
       }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       "@types/webidl-conversions": 7.0.0
     dev: false
 
@@ -16449,7 +16456,7 @@ packages:
       "@jest/expect": 29.5.0
       "@jest/test-result": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       co: 4.6.0
       dedent: 0.7.0
@@ -16469,7 +16476,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli@29.5.0(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest-cli@29.5.0(@types/node@18.11.9)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==,
@@ -16489,7 +16496,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.11
       import-local: 3.1.0
-      jest-config: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-config: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
       jest-util: 29.5.0
       jest-validate: 29.5.0
       prompts: 2.4.2
@@ -16500,7 +16507,7 @@ packages:
       - ts-node
     dev: true
 
-  /jest-config@29.5.0(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest-config@29.5.0(@types/node@18.11.9)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-kvDUKBnNJPNBmFFOhDbm59iu1Fii1Q6SxyhXfvylq3UTHbg6o7j/g8k2dZyXWLvfdKB1vAPxNZnMgtKJcmu3kA==,
@@ -16518,7 +16525,7 @@ packages:
       "@babel/core": 7.21.8
       "@jest/test-sequencer": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       babel-jest: 29.5.0(@babel/core@7.21.8)
       chalk: 4.1.2
       ci-info: 3.8.0
@@ -16538,7 +16545,7 @@ packages:
       pretty-format: 29.5.0
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1(@swc/core@1.3.56)(@types/node@16.18.25)(typescript@4.9.5)
+      ts-node: 10.9.1(@swc/core@1.3.56)(@types/node@18.11.9)(typescript@4.9.5)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -16595,7 +16602,7 @@ packages:
       "@jest/fake-timers": 29.5.0
       "@jest/types": 29.5.0
       "@types/jsdom": 20.0.1
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-mock: 29.5.0
       jest-util: 29.5.0
       jsdom: 20.0.3
@@ -16615,7 +16622,7 @@ packages:
       "@jest/environment": 29.5.0
       "@jest/fake-timers": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-mock: 29.5.0
       jest-util: 29.5.0
     dev: true
@@ -16636,7 +16643,7 @@ packages:
     dependencies:
       "@jest/types": 29.5.0
       "@types/graceful-fs": 4.1.6
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -16697,7 +16704,7 @@ packages:
     engines: { node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0 }
     dependencies:
       "@jest/types": 27.5.1
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
     dev: true
 
   /jest-mock@29.5.0:
@@ -16708,7 +16715,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-util: 29.5.0
 
   /jest-pnp-resolver@1.2.3(jest-resolve@29.5.0):
@@ -16777,7 +16784,7 @@ packages:
       "@jest/test-result": 29.5.0
       "@jest/transform": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -16811,7 +16818,7 @@ packages:
       "@jest/test-result": 29.5.0
       "@jest/transform": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       cjs-module-lexer: 1.2.2
       collect-v8-coverage: 1.0.1
@@ -16872,7 +16879,7 @@ packages:
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       chalk: 4.1.2
       ci-info: 3.8.0
       graceful-fs: 4.2.11
@@ -16902,7 +16909,7 @@ packages:
     dependencies:
       "@jest/test-result": 29.5.0
       "@jest/types": 29.5.0
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -16917,7 +16924,7 @@ packages:
       }
     engines: { node: ">= 10.13.0" }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
@@ -16928,13 +16935,13 @@ packages:
       }
     engines: { node: ^14.15.0 || ^16.10.0 || >=18.0.0 }
     dependencies:
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       jest-util: 29.5.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
     dev: true
 
-  /jest@29.5.0(@types/node@16.18.25)(ts-node@10.9.1):
+  /jest@29.5.0(@types/node@18.11.9)(ts-node@10.9.1):
     resolution:
       {
         integrity: sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==,
@@ -16950,7 +16957,7 @@ packages:
       "@jest/core": 29.5.0(ts-node@10.9.1)
       "@jest/types": 29.5.0
       import-local: 3.1.0
-      jest-cli: 29.5.0(@types/node@16.18.25)(ts-node@10.9.1)
+      jest-cli: 29.5.0(@types/node@18.11.9)(ts-node@10.9.1)
     transitivePeerDependencies:
       - "@types/node"
       - supports-color
@@ -24097,7 +24104,7 @@ packages:
       typescript: 4.9.5
     dev: false
 
-  /ts-node@10.9.1(@swc/core@1.3.56)(@types/node@16.18.25)(typescript@4.9.5):
+  /ts-node@10.9.1(@swc/core@1.3.56)(@types/node@18.11.9)(typescript@4.9.5):
     resolution:
       {
         integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
@@ -24120,7 +24127,7 @@ packages:
       "@tsconfig/node12": 1.0.11
       "@tsconfig/node14": 1.0.3
       "@tsconfig/node16": 1.0.3
-      "@types/node": 16.18.25
+      "@types/node": 18.11.9
       acorn: 8.8.2
       acorn-walk: 8.2.0
       arg: 4.1.3


### PR DESCRIPTION
## Description

Node `16` is now mostly unsupported. We need to make sure everything in this repo works with Node `18`.

- [x] Upgrade all GitHub workflows
- [x] Upgrade all Dockerfile
- [x] Upgrade dependencies in package.json (where applicable).

## Type of change

- [x] Chore

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
