### PR TITLE
@/charterafrica Allow multiple spotlight blocks in a page

### DIFF
--- a/apps/charterafrica/src/lib/data/common/processPageIndex.js
+++ b/apps/charterafrica/src/lib/data/common/processPageIndex.js
@@ -50,10 +50,11 @@ const processInfographic = (page) => {
 const processSpotlight = (page, api, context) => {
   const { blocks } = page;
   const { locale } = context;
-  const spotlightIndex = blocks.findIndex(
-    (block) => block.slug === "spotlight"
-  );
-  if (spotlightIndex > -1) {
+  let spotlightIndex = -1;
+  const indexOfSpotlightBlock = ({ slug }, i) =>
+    slug === "spotlight" && i > spotlightIndex;
+  spotlightIndex = blocks.findIndex(indexOfSpotlightBlock);
+  while (spotlightIndex > -1) {
     const spotlight = blocks[spotlightIndex];
 
     const spotlightItems = spotlight?.items?.map((item) => {
@@ -80,6 +81,7 @@ const processSpotlight = (page, api, context) => {
 
     spotlight.items = spotlightItems || null;
     blocks[spotlightIndex] = spotlight;
+    spotlightIndex = blocks.findIndex(indexOfSpotlightBlock);
   }
 };
 


### PR DESCRIPTION
## Description

Seems like Spotlight block is being reused to highlight podcasts. This PR updates the backend code to be aware of more than one single Spotlight block on a page.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

![localhost_3003](https://github.com/CodeForAfrica/ui/assets/1779590/92efc4bd-ce45-4819-9b17-e2f2747e5158)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
