### PR TITLE
Redirect `/resources` to `/resources/datasets`

### DIFF
--- a/apps/charterafrica/next.config.js
+++ b/apps/charterafrica/next.config.js
@@ -64,6 +64,11 @@ const nextConfig = {
         destination: "/opportunities#grants-fellowships",
         permanent: true,
       },
+      {
+        source: "/resources",
+        destination: "/resources/datasets",
+        permanent: true,
+      },
     ];
   },
   transpilePackages: ["@commons-ui/core", "@commons-ui/next"],

--- a/apps/charterafrica/src/middleware.page.js
+++ b/apps/charterafrica/src/middleware.page.js
@@ -6,7 +6,11 @@ export function middleware(req) {
   const slugsPathname = new URLSearchParams(req.nextUrl.search)
     .getAll("slugs")
     .join("/");
-  if (equalsIgnoringCase("knowledge", slugsPathname)) {
+  if (
+    ["knowledge", "resources"].some((slug) =>
+      equalsIgnoringCase(slug, slugsPathname),
+    )
+  ) {
     return NextResponse.redirect(new URL(req.nextUrl.pathname, req.url));
   }
   let hash;
@@ -29,5 +33,9 @@ export const config = {
   // need to match redirects defined in next.config.js for client-side routing
   // to work
   // https://nextjs.org/docs/api-reference/next.config.js/redirects
-  matcher: ["/knowledge/explainers/:path*", "/opportunities/:path*"],
+  matcher: [
+    "/knowledge/explainers/:path*",
+    "/opportunities/:path*",
+    "/resources/datasets/:path*",
+  ],
 };


### PR DESCRIPTION
## Description

`/resources` is an empty page parent to all resources page. Users should be redirect to actual content page similar to how we handle `/knowledge` and `/opportunities`. This PR redirect `/resources` to `/resources/datasets`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

N/A

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
