### PR TITLE
@/charterafrica Hide opportunities if empty

### DIFF
--- a/apps/charterafrica/src/components/OpportunityPage/OpportunityPage.js
+++ b/apps/charterafrica/src/components/OpportunityPage/OpportunityPage.js
@@ -45,70 +45,75 @@ const OpportunityPage = React.forwardRef(function OpportunityPage(props, ref) {
       ref={ref}
     >
       <OpportunityHeader title={header} />
-      {itemsPerOpportunity.map(({ config, itemsPerStatus, label }, i) => (
-        <Section
-          sx={{
-            px: { xs: 7.5, sm: 0 },
-            py: 5,
-            "&:last-child": {
-              pb: 0,
-            },
-          }}
-          key={label}
-        >
-          <RichTypography
-            color="neutral.dark"
-            pb={5}
-            textAlign={{
-              xs: "center",
-              md: "left",
+      {itemsPerOpportunity.map(({ config, itemsPerStatus, label }, i) => {
+        if (!itemsPerStatus?.length) {
+          return null;
+        }
+        return (
+          <Section
+            sx={{
+              px: { xs: 7.5, sm: 0 },
+              py: 5,
+              "&:last-child": {
+                pb: 0,
+              },
             }}
-            variant="h3Small"
+            key={label}
           >
-            {label}
-          </RichTypography>
+            <RichTypography
+              color="neutral.dark"
+              pb={5}
+              textAlign={{
+                xs: "center",
+                md: "left",
+              }}
+              variant="h3Small"
+            >
+              {label}
+            </RichTypography>
 
-          {itemsPerStatus.map((item) => (
-            <React.Fragment key={item.title}>
-              <OpportunityCards
-                config={config}
-                // Featured should be displayed at the top of the block only
-                featured={i === 0 ? featured : undefined}
-                items={item.items}
-                title={item.title}
-                sx={{
-                  display: {
-                    xs: config?.showOnMobile?.includes(item.title)
-                      ? "block"
-                      : "none",
-                    md: "block",
-                  },
-                }}
-                key={item.title}
-              />
-              <Divider
-                sx={{
-                  border: "1px solid",
-                  borderColor: "neutral.light",
-                  color: "neutral.light",
-                  height: "0px",
-                  my: 5,
-                  width: "100%",
-                  display: {
-                    xs: config?.showOnMobile?.includes(item.title)
-                      ? "block"
-                      : "none",
-                    md: "block",
-                  },
-                  "&:last-child": {
-                    marginBottom: 0,
-                  },
-                }}
-              />
-            </React.Fragment>
-          ))}
-        </Section>
-      ))}
+            {itemsPerStatus.map((item) => (
+              <React.Fragment key={item.title}>
+                <OpportunityCards
+                  config={config}
+                  // Featured should be displayed at the top of the block only
+                  featured={i === 0 ? featured : undefined}
+                  items={item.items}
+                  title={item.title}
+                  sx={{
+                    display: {
+                      xs: config?.showOnMobile?.includes(item.title)
+                        ? "block"
+                        : "none",
+                      md: "block",
+                    },
+                  }}
+                  key={item.title}
+                />
+                <Divider
+                  sx={{
+                    border: "1px solid",
+                    borderColor: "neutral.light",
+                    color: "neutral.light",
+                    height: "0px",
+                    my: 5,
+                    width: "100%",
+                    display: {
+                      xs: config?.showOnMobile?.includes(item.title)
+                        ? "block"
+                        : "none",
+                      md: "block",
+                    },
+                    "&:last-child": {
+                      marginBottom: 0,
+                    },
+                  }}
+                />
+              </React.Fragment>
+            ))}
+          </Section>
+        );
+      })}
     </Box>
   );
 });


### PR DESCRIPTION
## Description

Do not show empty opportunities heading if there are actually no items.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

Fellowships are hidden since there are items at the moment.

![S](https://github.com/CodeForAfrica/ui/assets/1779590/4d335c44-4d18-403d-8ef6-fc07f1e5ce2a)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
