### PR TITLE
Fix failing build if no error page

### DIFF
--- a/apps/codeforafrica/src/lib/data/common/index.js
+++ b/apps/codeforafrica/src/lib/data/common/index.js
@@ -44,37 +44,41 @@ function getPageSlug({ params }) {
   return params?.slugs?.[pageSlugIndex] || "index";
 }
 
+function getDefaultErrorPageProps() {
+  return {
+    title: "Page not found. ",
+    subtitle: [
+      {
+        children: [
+          {
+            text: "Visit our ",
+            children: null,
+          },
+          {
+            type: "link",
+            newTab: false,
+            url: "/",
+            children: [
+              {
+                text: "homepage",
+                children: null,
+              },
+            ],
+            href: "/",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 export async function getPageProps(api, context) {
   const slug = getPageSlug(context);
   const {
     docs: [page],
   } = await api.findPage(slug);
   if (!page && (slug === "404" || slug === "500")) {
-    return {
-      title: "Page not found",
-      subtitle: [
-        {
-          children: [
-            {
-              text: "Visit our ",
-              children: null,
-            },
-            {
-              type: "link",
-              newTab: false,
-              url: "/",
-              children: [
-                {
-                  text: "homepage",
-                  children: null,
-                },
-              ],
-              href: "/",
-            },
-          ],
-        },
-      ],
-    };
+    return getDefaultErrorPageProps();
   }
   if (!page) {
     return null;

--- a/apps/codeforafrica/src/lib/data/common/index.js
+++ b/apps/codeforafrica/src/lib/data/common/index.js
@@ -44,14 +44,62 @@ function getPageSlug({ params }) {
   return params?.slugs?.[pageSlugIndex] || "index";
 }
 
-function getDefaultErrorPageProps() {
+function getDefaultErrorPageProps(statusCode = 404) {
+  if (statusCode === 500) {
+    return {
+      title: "Server Error. ",
+      subtitle: [
+        {
+          children: [
+            {
+              text: "Don't worry!, you can head back to our ",
+              children: null,
+            },
+            {
+              type: "link",
+              newTab: false,
+              url: "/",
+              children: [
+                {
+                  text: "homepage",
+                  children: null,
+                },
+              ],
+              href: "/",
+            },
+            {
+              text: "check out our most recent ",
+              children: null,
+            },
+            {
+              type: "link",
+              newTab: false,
+              url: "/projects",
+              children: [
+                {
+                  text: "projects",
+                  children: null,
+                },
+              ],
+              href: "/projects",
+            },
+            {
+              text: ", or read below some of the contents produced by our amazing team while the technical team is working on fixing the issue.",
+              children: null,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
   return {
-    title: "Page not found. ",
+    title: "Whoops! This page got lost in conversation! ",
     subtitle: [
       {
         children: [
           {
-            text: "Visit our ",
+            text: "Don't worry!, you can head back to our ",
             children: null,
           },
           {
@@ -66,6 +114,26 @@ function getDefaultErrorPageProps() {
             ],
             href: "/",
           },
+          {
+            text: "check out our most recent ",
+            children: null,
+          },
+          {
+            type: "link",
+            newTab: false,
+            url: "/projects",
+            children: [
+              {
+                text: "projects",
+                children: null,
+              },
+            ],
+            href: "/projects",
+          },
+          {
+            text: ", or read below some of the contents produced by our amazing team.",
+            children: null,
+          },
         ],
       },
     ],
@@ -77,7 +145,10 @@ export async function getPageProps(api, context) {
   const {
     docs: [page],
   } = await api.findPage(slug);
-  if (!page && (slug === "404" || slug === "500")) {
+  if (!page) {
+    if (slug === "500") {
+      return getDefaultErrorPageProps(500);
+    }
     return getDefaultErrorPageProps();
   }
   if (!page) {

--- a/apps/codeforafrica/src/lib/data/common/index.js
+++ b/apps/codeforafrica/src/lib/data/common/index.js
@@ -49,6 +49,11 @@ export async function getPageProps(api, context) {
   const {
     docs: [page],
   } = await api.findPage(slug);
+  if (!page && (slug === "404" || slug === "500")) {
+    return {
+      title: "Page not found",
+    };
+  }
   if (!page) {
     return null;
   }

--- a/apps/codeforafrica/src/lib/data/common/index.js
+++ b/apps/codeforafrica/src/lib/data/common/index.js
@@ -52,6 +52,28 @@ export async function getPageProps(api, context) {
   if (!page && (slug === "404" || slug === "500")) {
     return {
       title: "Page not found",
+      subtitle: [
+        {
+          children: [
+            {
+              text: "Visit our ",
+              children: null,
+            },
+            {
+              type: "link",
+              newTab: false,
+              url: "/",
+              children: [
+                {
+                  text: "homepage",
+                  children: null,
+                },
+              ],
+              href: "/",
+            },
+          ],
+        },
+      ],
     };
   }
   if (!page) {

--- a/apps/codeforafrica/src/lib/data/common/index.js
+++ b/apps/codeforafrica/src/lib/data/common/index.js
@@ -44,8 +44,8 @@ function getPageSlug({ params }) {
   return params?.slugs?.[pageSlugIndex] || "index";
 }
 
-function getDefaultErrorPageProps(statusCode = 404) {
-  if (statusCode === 500) {
+function getDefaultErrorPageProps(slug = "404") {
+  if (slug === "500") {
     return {
       title: "Server Error. ",
       subtitle: [
@@ -146,12 +146,9 @@ export async function getPageProps(api, context) {
     docs: [page],
   } = await api.findPage(slug);
   if (!page) {
-    if (slug === "500") {
-      return getDefaultErrorPageProps(500);
+    if (["404", "500"].includes(slug)) {
+      return getDefaultErrorPageProps(slug);
     }
-    return getDefaultErrorPageProps();
-  }
-  if (!page) {
     return null;
   }
 

--- a/apps/codeforafrica/src/pages/_error.page.js
+++ b/apps/codeforafrica/src/pages/_error.page.js
@@ -6,7 +6,7 @@ function CustomError(props) {
 }
 
 export async function getStaticProps(context) {
-  return getPageStaticProps(context, "/_error");
+  return getPageStaticProps({ ...context, params: { slugs: ["500"] } });
 }
 
 export default CustomError;

--- a/apps/codeforafrica/src/pages/_error.test.js
+++ b/apps/codeforafrica/src/pages/_error.test.js
@@ -9,7 +9,7 @@ import theme from "@/codeforafrica/theme";
 const render = createRender({ theme });
 
 const defaultProps = {
-  sections: [],
+  blocks: [],
 };
 
 describe("/404", () => {


### PR DESCRIPTION
## Description
This PR fixes a bug which causes the build to fail if an error page has not been created in the CMS. It introduces default values for the error page.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
