### PR TITLE
Fix go to repository broken link

### DIFF
--- a/apps/charterafrica/contrib/dokku/Dockerfile
+++ b/apps/charterafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/charterafrica-ui:0.1.10
+FROM codeforafrica/charterafrica-ui:0.1.11

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charterafrica",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the official code for https://charter.africa site",

--- a/apps/charterafrica/src/components/Tool/Tool.js
+++ b/apps/charterafrica/src/components/Tool/Tool.js
@@ -63,7 +63,7 @@ const Tool = React.forwardRef(function Tool(props, ref) {
                   {name}
                 </RichTypography>
                 {externalLink?.href ? (
-                  <Link href={externalLink?.href}>
+                  <Link href={externalLink.href}>
                     <SvgIcon
                       inheritViewBox
                       component={ExternalLink}

--- a/apps/charterafrica/src/components/Tool/Tool.js
+++ b/apps/charterafrica/src/components/Tool/Tool.js
@@ -63,8 +63,8 @@ const Tool = React.forwardRef(function Tool(props, ref) {
                   {name}
                 </RichTypography>
                 <Button
-                  component={externalLink.href ? Link : undefined}
-                  href={externalLink.href}
+                  component={externalLink?.href ? Link : undefined}
+                  href={externalLink?.href}
                 >
                   <SvgIcon
                     inheritViewBox

--- a/apps/charterafrica/src/components/Tool/Tool.js
+++ b/apps/charterafrica/src/components/Tool/Tool.js
@@ -18,7 +18,6 @@ const Tool = React.forwardRef(function Tool(props, ref) {
   const {
     image,
     name,
-    link,
     organisation,
     theme,
     operatingCountries,
@@ -34,6 +33,7 @@ const Tool = React.forwardRef(function Tool(props, ref) {
     partners,
     tools,
     toolsTitle,
+    externalLink,
   } = props;
   return (
     <Box bgcolor="common.white" ref={ref}>
@@ -62,7 +62,10 @@ const Tool = React.forwardRef(function Tool(props, ref) {
                 <RichTypography color="neutral.dark" variant="h2SemiBold">
                   {name}
                 </RichTypography>
-                <Link href={link.href}>
+                <Button
+                  component={externalLink.href ? Link : undefined}
+                  href={externalLink.href}
+                >
                   <SvgIcon
                     inheritViewBox
                     component={ExternalLink}
@@ -73,7 +76,7 @@ const Tool = React.forwardRef(function Tool(props, ref) {
                       width: 32,
                     }}
                   />
-                </Link>
+                </Button>
               </Box>
             </Grid>
             <Grid item>

--- a/apps/charterafrica/src/components/Tool/Tool.js
+++ b/apps/charterafrica/src/components/Tool/Tool.js
@@ -62,21 +62,20 @@ const Tool = React.forwardRef(function Tool(props, ref) {
                 <RichTypography color="neutral.dark" variant="h2SemiBold">
                   {name}
                 </RichTypography>
-                <Button
-                  component={externalLink?.href ? Link : undefined}
-                  href={externalLink?.href}
-                >
-                  <SvgIcon
-                    inheritViewBox
-                    component={ExternalLink}
-                    sx={{
-                      color: "text.primary",
-                      fill: "none",
-                      height: 32,
-                      width: 32,
-                    }}
-                  />
-                </Button>
+                {externalLink?.href ? (
+                  <Link href={externalLink?.href}>
+                    <SvgIcon
+                      inheritViewBox
+                      component={ExternalLink}
+                      sx={{
+                        color: "text.primary",
+                        fill: "none",
+                        height: 32,
+                        width: 32,
+                      }}
+                    />
+                  </Link>
+                ) : null}
               </Box>
             </Grid>
             <Grid item>

--- a/apps/charterafrica/src/components/Tool/Tool.snap.js
+++ b/apps/charterafrica/src/components/Tool/Tool.snap.js
@@ -138,7 +138,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                 class="MuiBox-root css-oqyb22"
               >
                 <div
-                  class="MuiStack-root css-hhlonh-MuiStack-root"
+                  class="MuiStack-root css-82jnlo-MuiStack-root"
                 >
                   <div
                     class="MuiTypography-root MuiTypography-p3 css-1orwtxp-MuiTypography-root"
@@ -146,7 +146,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                     Share via
                   </div>
                   <div
-                    class="MuiStack-root css-b6wkik-MuiStack-root"
+                    class="MuiStack-root css-6za6r5-MuiStack-root"
                   >
                     <button
                       aria-label="twitter"
@@ -250,7 +250,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   26
                 </div>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -266,7 +266,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -282,7 +282,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -298,7 +298,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg

--- a/apps/charterafrica/src/components/Tool/Tool.snap.js
+++ b/apps/charterafrica/src/components/Tool/Tool.snap.js
@@ -34,17 +34,6 @@ exports[`<Tool /> renders unchanged 1`] = `
               >
                 Tool Name
               </div>
-              <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-18jkoo-MuiButtonBase-root-MuiButton-root"
-                tabindex="0"
-                type="button"
-              >
-                <div
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-mg30as-MuiSvgIcon-root"
-                  focusable="false"
-                />
-              </button>
             </div>
           </div>
           <div

--- a/apps/charterafrica/src/components/Tool/Tool.snap.js
+++ b/apps/charterafrica/src/components/Tool/Tool.snap.js
@@ -34,18 +34,17 @@ exports[`<Tool /> renders unchanged 1`] = `
               >
                 Tool Name
               </div>
-              <a
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways active css-4xpak5-MuiTypography-root-MuiLink-root"
-                href="https://git.com"
-                rel="noreferrer noopener"
-                target="_blank"
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium css-18jkoo-MuiButtonBase-root-MuiButton-root"
+                tabindex="0"
+                type="button"
               >
                 <div
                   aria-hidden="true"
                   class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-mg30as-MuiSvgIcon-root"
                   focusable="false"
                 />
-              </a>
+              </button>
             </div>
           </div>
           <div
@@ -139,7 +138,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                 class="MuiBox-root css-oqyb22"
               >
                 <div
-                  class="MuiStack-root css-82jnlo-MuiStack-root"
+                  class="MuiStack-root css-hhlonh-MuiStack-root"
                 >
                   <div
                     class="MuiTypography-root MuiTypography-p3 css-1orwtxp-MuiTypography-root"
@@ -147,7 +146,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                     Share via
                   </div>
                   <div
-                    class="MuiStack-root css-6za6r5-MuiStack-root"
+                    class="MuiStack-root css-b6wkik-MuiStack-root"
                   >
                     <button
                       aria-label="twitter"
@@ -251,7 +250,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   26
                 </div>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -267,7 +266,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -283,7 +282,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg
@@ -299,7 +298,7 @@ exports[`<Tool /> renders unchanged 1`] = `
                   </svg>
                 </a>
                 <a
-                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-6bqc4m-MuiTypography-root-MuiLink-root-MuiAvatar-root"
+                  class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiAvatar-root MuiAvatar-circular MuiAvatar-colorDefault MuiAvatarGroup-avatar active css-1sel0v5-MuiTypography-root-MuiLink-root-MuiAvatar-root"
                   href=""
                 >
                   <svg

--- a/apps/charterafrica/src/lib/data/common/processPageTools.js
+++ b/apps/charterafrica/src/lib/data/common/processPageTools.js
@@ -33,21 +33,6 @@ const queryBuilder = (query) => {
   return where;
 };
 
-const getRepoLink = (tool) => {
-  if (!tool.externalId) {
-    return null;
-  }
-  switch (tool.source) {
-    case "github":
-      return `https://github.com/${tool.externalId.replace(
-        "https://github.com/",
-        "",
-      )}`;
-    default:
-      return "";
-  }
-};
-
 async function processPageSingleTool(page, api, context) {
   const { params, locale } = context;
   const { slug: collection } = page;
@@ -85,11 +70,11 @@ async function processPageSingleTool(page, api, context) {
         ...tool,
         slug: "tool",
         contribute: {
-          href: getRepoLink(tool),
+          href: tool.repoLink,
           label: filterLabels.contribute,
         },
         goToRepo: {
-          href: getRepoLink(tool),
+          href: tool.repoLink,
           label: filterLabels.goToRepo,
         },
         topicLabel: filterLabels.theme,

--- a/apps/charterafrica/src/lib/data/common/processPageTools.js
+++ b/apps/charterafrica/src/lib/data/common/processPageTools.js
@@ -34,9 +34,15 @@ const queryBuilder = (query) => {
 };
 
 const getRepoLink = (tool) => {
-  switch (tool.source && tool.externalId) {
+  if (!tool.externalId) {
+    return null;
+  }
+  switch (tool.source) {
     case "github":
-      return `https://github.com/${tool.externalId}`;
+      return `https://github.com/${tool.externalId.replace(
+        "https://github.com/",
+        "",
+      )}`;
     default:
       return "";
   }
@@ -113,6 +119,9 @@ async function processPageSingleTool(page, api, context) {
         commitText: filterLabels.lastCommit,
         forksText: filterLabels.forks,
         starsText: filterLabels.stars,
+        externalLink: {
+          href: tool.docLink ?? null,
+        },
       },
     ],
   };

--- a/apps/charterafrica/src/payload/utils/nestCollectionUnderPage.js
+++ b/apps/charterafrica/src/payload/utils/nestCollectionUnderPage.js
@@ -16,7 +16,7 @@ function nestCollectionUnderPage(pageSlug) {
     } catch (error) {
       // TODO(kilemensi): Add Sentry to payload & report errors
     }
-    return { ...doc, link: { href } };
+    return { ...doc, docLink: doc.link ?? null, link: { href } };
   };
 }
 


### PR DESCRIPTION

## Description

The "go to repo" button on the "tools individual" page of the charter site is not redirecting to GitHub, neither is the expand icon.

- nestPageUnderCollection function overrides link field in a component. This PR introduces docLink field to avoid this error.
Fixes # [issue](https://code4africa.slack.com/archives/C04AJ0124H1/p1696578745144429)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
