### PR TITLE
Update DOKKU_REMOTE_URL to dev environment

### DIFF
--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -2,7 +2,7 @@ name: charterAFRICA | Deploy | DEV
 
 on:
   push:
-    branches: [main]
+    branches: [ft/fix-charterafrica-dev-deployment]
     paths:
       - "apps/charterafrica/**"
       - "Dockerfile.charterafrica"
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  DOKKU_REMOTE_URL: "ssh://dokku@ui-1.prod.codeforafrica.org/charterafrica"
+  DOKKU_REMOTE_URL: "ssh://dokku@ui-1.dev.codeforafrica.org/charterafrica"
   IMAGE_NAME: "codeforafrica/charterafrica-ui"
   NEXT_PUBLIC_APP_URL: "https://charterafrica.dev.codeforafrica.org"
   SENTRY_ENV: "development"

--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "apps/charterafrica/**"
       - "Dockerfile.charterafrica"
+      - ".github/workflows/charterafrica-deploy-dev.yml"
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -2,7 +2,7 @@ name: charterAFRICA | Deploy | DEV
 
 on:
   push:
-    branches: [ft/fix-charterafrica-dev-deployment]
+    branches: [main]
     paths:
       - "apps/charterafrica/**"
       - "Dockerfile.charterafrica"

--- a/.github/workflows/codeforafrica-deploy-dev-app.yml
+++ b/.github/workflows/codeforafrica-deploy-dev-app.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - "apps/codeforafrica/**"
       - "Dockerfile.codeforafrica"
-      - ".github/**"
+      - ".github/workflows/codeforafrica-deploy-dev-app.yml"
 
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref }}"

--- a/.github/workflows/codeforafrica-deploy-review-app.yml
+++ b/.github/workflows/codeforafrica-deploy-review-app.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - "apps/codeforafrica/**"
       - "Dockerfile.codeforafrica"
-      - ".github/**"
+      - ".github/workflows/codeforafrica-deploy-review.yml"
 concurrency:
   group: "${{ github.workflow }} @ ${{ github.ref }}"
   cancel-in-progress: false


### PR DESCRIPTION
Description

Currently, charterAfrica dev has been deploying to the wrong dokku remote URL. This fixes that issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
