### PR TITLE
Replace Keyfile with string credentials

### DIFF
--- a/.github/workflows/vpnmanager-deploy-dev.yml
+++ b/.github/workflows/vpnmanager-deploy-dev.yml
@@ -2,7 +2,7 @@ name: VPN Manager | Deploy | DEV
 
 on:
   push:
-    branches: [main]
+    branches: [feature/fix-cron-failing]
     paths:
       - "apps/vpnmanager/**"
       - "Dockerfile.vpnmanager"

--- a/apps/vpnmanager/src/lib/data/spreadsheet.ts
+++ b/apps/vpnmanager/src/lib/data/spreadsheet.ts
@@ -4,8 +4,9 @@ import { SheetRow } from "@/vpnmanager/types";
 import { toCamelCase } from "@/vpnmanager/utils";
 
 function gSheet() {
+  const credentials = JSON.parse(process.env.NEXT_APP_GOOGLE_CREDENTIALS ?? '{}');
   const auth = new google.auth.GoogleAuth({
-    keyFile: process.env.NEXT_APP_GOOGLE_CREDENTIALS,
+    credentials,
     scopes: ["https://www.googleapis.com/auth/spreadsheets"],
   });
   return google.sheets({ version: "v4", auth });

--- a/apps/vpnmanager/src/lib/processUsers.ts
+++ b/apps/vpnmanager/src/lib/processUsers.ts
@@ -41,6 +41,7 @@ export async function processUser(item: SheetRow) {
 
 export async function processNewUsers() {
   const users = await spreadsheet.newUsers();
+  console.log(users)
   const promises = users.map((item) => processUser(item));
   const settled = await Promise.allSettled(promises);
   const fulfilled = settled


### PR DESCRIPTION
## Description

At the moment, google configs are a path to keyfile which may be set to a path not inside a docker container.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
