### PR TITLE
@/pesayetu/ reduce the number stories pages built to just main ones

### DIFF
--- a/apps/pesayetu/src/pages/stories/[[...slug]].js
+++ b/apps/pesayetu/src/pages/stories/[[...slug]].js
@@ -108,7 +108,15 @@ Index.defaultProps = {
 };
 
 export async function getStaticPaths() {
-  return getPostTypeStaticPaths(postType);
+  const { paths: allPaths = [] } =
+    (await getPostTypeStaticPaths(postType)) || {};
+  // Generate static pages for main stories pages i.e. stories/news and stories/insights
+  const paths = allPaths.filter(({ params }) => params?.slug?.length === 1);
+
+  return {
+    paths,
+    fallback: "blocking",
+  };
 }
 
 export async function getStaticProps({ params, preview, previewData }) {


### PR DESCRIPTION
## Description

Instead of building all stories pages (over 100) at build time, this PR reduces them down to main ones i.e. only one depth from `/stories`. This effectively means only 2 pages are now build:

  1. `/stories/news`, and
  2. `/stories/insights`

Overall, this reduces the total number of pages that needs to be built at build time from about 140 to just 20.

First step towards #675 

## Type of change

Please delete options that are not relevant.

- [x] Chore

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

