### PR TITLE
Bugfix/charterafrica build

### DIFF
--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -2,7 +2,7 @@ name: charterAFRICA | Deploy | DEV
 
 on:
   push:
-    branches: [main]
+    branches: [bugfix/charterafrica-build]
     paths:
       - "apps/charterafrica/**"
       - "Dockerfile"

--- a/.github/workflows/charterafrica-deploy-dev.yml
+++ b/.github/workflows/charterafrica-deploy-dev.yml
@@ -2,7 +2,7 @@ name: charterAFRICA | Deploy | DEV
 
 on:
   push:
-    branches: [bugfix/charterafrica-build]
+    branches: [main]
     paths:
       - "apps/charterafrica/**"
       - "Dockerfile"

--- a/apps/charterafrica/contrib/dokku/Dockerfile
+++ b/apps/charterafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/charterafrica-ui:0.1.27
+FROM codeforafrica/charterafrica-ui:0.1.28

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charterafrica",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the official code for https://charter.africa site",

--- a/apps/charterafrica/src/lib/data/local/index.js
+++ b/apps/charterafrica/src/lib/data/local/index.js
@@ -25,7 +25,11 @@ export async function getServerSideTags(collection, context) {
   return getTags(collection, api, context);
 }
 
-export async function getPageServerSideProps(context) {
+export async function getPageServerSideProps({
+  locale = "en",
+  ...contextWithoutLocale
+}) {
+  const context = { ...contextWithoutLocale, locale };
   const props = await getPageProps(api, context);
 
   if (!props) {

--- a/apps/charterafrica/src/pages/_app.page.js
+++ b/apps/charterafrica/src/pages/_app.page.js
@@ -75,7 +75,7 @@ MyApp.getInitialProps = async (appContext) => {
   const appProps = await App.getInitialProps(appContext);
   const {
     Component,
-    router: { defaultLocale, locale, locales },
+    router: { defaultLocale, locale = "en", locales },
     ctx: appCtx,
   } = appContext;
   let pageProps = {};


### PR DESCRIPTION
## Description

Tools, Organisations and contributors throws 500 error page on production from the latest build. This happens because when trying to access code labels, locale is undefined. This PR ensures that locale can never be undefined when getting server side props.

This has been tested on [dev server](https://charterafrica.dev.codeforafrica.org/resources/tools).


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
