### PR TITLE
Bugfix/761 roboshield stylings

### DIFF
--- a/apps/roboshield/src/assets/icons/Type=back, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=back, Size=24, Color=CurrentColor.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 12H5" stroke="#1120E1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M12 19L5 12L12 5" stroke="#1120E1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 12H5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 19L5 12L12 5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/apps/roboshield/src/assets/icons/Type=back, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=back, Size=24, Color=CurrentColor.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 12H5" stroke="#1120E1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M12 19L5 12L12 5" stroke="#1120E1" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/roboshield/src/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/roboshield/src/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg
@@ -1,4 +1,4 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M20 9H11C9.89543 9 9 9.89543 9 11V20C9 21.1046 9.89543 22 11 22H20C21.1046 22 22 21.1046 22 20V11C22 9.89543 21.1046 9 20 9Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5 15H4C3.46957 15 2.96086 14.7893 2.58579 14.4142C2.21071 14.0391 2 13.5304 2 13V4C2 3.46957 2.21071 2.96086 2.58579 2.58579C2.96086 2.21071 3.46957 2 4 2H13C13.5304 2 14.0391 2.21071 14.4142 2.58579C14.7893 2.96086 15 3.46957 15 4V5" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/apps/roboshield/src/assets/icons/Type=reset, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=reset, Size=24, Color=CurrentColor.svg
@@ -1,0 +1,6 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 1L21 5L17 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 11V9C3 7.93913 3.42143 6.92172 4.17157 6.17157C4.92172 5.42143 5.93913 5 7 5H21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 23L3 19L7 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 13V15C21 16.0609 20.5786 17.0783 19.8284 17.8284C19.0783 18.5786 18.0609 19 17 19H3" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/roboshield/src/assets/icons/Type=reset, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=reset, Size=24, Color=CurrentColor.svg
@@ -1,6 +1,6 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M17 1L21 5L17 9" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M3 11V9C3 7.93913 3.42143 6.92172 4.17157 6.17157C4.92172 5.42143 5.93913 5 7 5H21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7 23L3 19L7 15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M21 13V15C21 16.0609 20.5786 17.0783 19.8284 17.8284C19.0783 18.5786 18.0609 19 17 19H3" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 1L21 5L17 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 11V9C3 7.93913 3.42143 6.92172 4.17157 6.17157C4.92172 5.42143 5.93913 5 7 5H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 23L3 19L7 15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M21 13V15C21 16.0609 20.5786 17.0783 19.8284 17.8284C19.0783 18.5786 18.0609 19 17 19H3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/apps/roboshield/src/assets/icons/Type=save, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=save, Size=24, Color=CurrentColor.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 21V13H7V21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 3V8H15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/apps/roboshield/src/assets/icons/Type=save, Size=24, Color=CurrentColor.svg
+++ b/apps/roboshield/src/assets/icons/Type=save, Size=24, Color=CurrentColor.svg
@@ -1,5 +1,5 @@
 <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M17 21V13H7V21" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-<path d="M7 3V8H15" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M19 21H5C4.46957 21 3.96086 20.7893 3.58579 20.4142C3.21071 20.0391 3 19.5304 3 19V5C3 4.46957 3.21071 3.96086 3.58579 3.58579C3.96086 3.21071 4.46957 3 5 3H16L21 8V19C21 19.5304 20.7893 20.0391 20.4142 20.4142C20.0391 20.7893 19.5304 21 19 21Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M17 21V13H7V21" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M7 3V8H15" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/apps/roboshield/src/components/Code/Code.tsx
+++ b/apps/roboshield/src/components/Code/Code.tsx
@@ -1,4 +1,9 @@
-import { Box, Button, Grid, Stack } from "@mui/material";
+import { Box, Button, Grid, Stack, SvgIcon } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import CopyIcon from "@/roboshield/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg";
+import SaveIcon from "@/roboshield/assets/icons/Type=save, Size=24, Color=CurrentColor.svg";
+import BackIcon from "@/roboshield/assets/icons/Type=back, Size=24, Color=CurrentColor.svg";
+import ResetIcon from "@/roboshield/assets/icons/Type=reset, Size=24, Color=CurrentColor.svg";
 
 import CodeEditor from "./CodeEditor";
 
@@ -28,6 +33,8 @@ export default function Code(props: CodeProps) {
   const handleCodeChange = (newCode: string) => {
     onCodeChange(newCode);
   };
+  const theme = useTheme();
+
   return (
     <Box
       sx={{
@@ -47,7 +54,20 @@ export default function Code(props: CodeProps) {
             <Button
               variant="contained"
               color="primary"
-              sx={{ mt: 2 }}
+              sx={{
+                mt: 2,
+                "&:hover .MuiSvgIcon-root path": {
+                  stroke: theme.palette.primary.main,
+                },
+              }}
+              startIcon={
+                <SvgIcon
+                  component={CopyIcon}
+                  sx={{
+                    fill: "transparent",
+                  }}
+                />
+              }
               onClick={onCopy}
               disabled={!showButtons}
             >
@@ -55,6 +75,14 @@ export default function Code(props: CodeProps) {
             </Button>
             <Button
               variant="contained"
+              startIcon={
+                <SvgIcon
+                  component={SaveIcon}
+                  sx={{
+                    fill: "transparent",
+                  }}
+                />
+              }
               sx={{
                 mt: 2,
                 background: "#000000",
@@ -62,6 +90,9 @@ export default function Code(props: CodeProps) {
                 "&:hover": {
                   background: "none",
                   color: "#000000",
+                },
+                "&:hover .MuiSvgIcon-root path": {
+                  stroke: theme.palette.text.primary,
                 },
               }}
               onClick={onDownload}
@@ -71,6 +102,17 @@ export default function Code(props: CodeProps) {
             </Button>
             <Button
               variant="outlined"
+              startIcon={
+                <SvgIcon
+                  component={BackIcon}
+                  sx={{
+                    stroke: "red",
+                    fill: "white",
+                    color: "red",
+                    transition: "stroke 0.3s, fill 0.3s",
+                  }}
+                />
+              }
               color="primary"
               sx={{
                 mt: 2,
@@ -94,13 +136,24 @@ export default function Code(props: CodeProps) {
           >
             <Button
               variant="contained"
+              startIcon={
+                <SvgIcon
+                  component={ResetIcon}
+                  sx={{
+                    fill: "transparent",
+                  }}
+                />
+              }
               sx={{
-                display: "inline-block",
-                background: "#FE2500",
-                border: "1px solid #FE2500",
+                mt: 2,
+                background: theme.palette.error.main,
+                border: `1px solid ${theme.palette.error.main}`,
                 "&:hover": {
                   background: "none",
-                  color: "#FE2500",
+                  color: theme.palette.error.main,
+                },
+                "&:hover .MuiSvgIcon-root path": {
+                  stroke: theme.palette.error.main,
                 },
               }}
               onClick={onReset}

--- a/apps/roboshield/src/components/Code/Code.tsx
+++ b/apps/roboshield/src/components/Code/Code.tsx
@@ -132,9 +132,9 @@ export default function Code(props: CodeProps) {
                   }}
                 />
               }
-              sx={(theme: Theme) => ({
-                background: theme.palette.error.main,
-                borderColor: theme.palette.error.main,
+              sx={{
+                background: "error.main",
+                borderColor: "error.main",
                 "&:hover": {
                   color: "error.main",
                 },

--- a/apps/roboshield/src/components/Code/Code.tsx
+++ b/apps/roboshield/src/components/Code/Code.tsx
@@ -82,8 +82,8 @@ export default function Code(props: CodeProps) {
                 />
               }
               sx={(theme: Theme) => ({
-                background: theme.palette.text.primary,
-                borderColor: theme.palette.text.primary,
+                bgcolor: "text.primary",
+                borderColor: "text.primary",
                 "&:hover": {
                   color: "text.primary",
                 },
@@ -133,12 +133,12 @@ export default function Code(props: CodeProps) {
                 />
               }
               sx={{
-                background: "error.main",
+                bgcolor: "error.main",
                 borderColor: "error.main",
                 "&:hover": {
                   color: "error.main",
                 },
-              })}
+              }}
               onClick={onReset}
               disabled={!showButtons}
             >

--- a/apps/roboshield/src/components/Code/Code.tsx
+++ b/apps/roboshield/src/components/Code/Code.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Grid, Stack, SvgIcon } from "@mui/material";
-import { useTheme } from "@mui/material/styles";
+import { Theme } from "@mui/material";
 import CopyIcon from "@/roboshield/assets/icons/Type=copy, Size=24, Color=CurrentColor.svg";
 import SaveIcon from "@/roboshield/assets/icons/Type=save, Size=24, Color=CurrentColor.svg";
 import BackIcon from "@/roboshield/assets/icons/Type=back, Size=24, Color=CurrentColor.svg";
@@ -33,7 +33,6 @@ export default function Code(props: CodeProps) {
   const handleCodeChange = (newCode: string) => {
     onCodeChange(newCode);
   };
-  const theme = useTheme();
 
   return (
     <Box
@@ -54,12 +53,11 @@ export default function Code(props: CodeProps) {
             <Button
               variant="contained"
               color="primary"
-              sx={{
-                mt: 2,
-                "&:hover .MuiSvgIcon-root path": {
-                  stroke: theme.palette.primary.main,
+              sx={(theme: Theme) => ({
+                "&:hover": {
+                  color: "primary",
                 },
-              }}
+              })}
               startIcon={
                 <SvgIcon
                   component={CopyIcon}
@@ -83,18 +81,13 @@ export default function Code(props: CodeProps) {
                   }}
                 />
               }
-              sx={{
-                mt: 2,
-                background: "#000000",
-                border: "1px solid #000000",
+              sx={(theme: Theme) => ({
+                background: theme.palette.text.primary,
+                borderColor: theme.palette.text.primary,
                 "&:hover": {
-                  background: "none",
-                  color: "#000000",
+                  color: "text.primary",
                 },
-                "&:hover .MuiSvgIcon-root path": {
-                  stroke: theme.palette.text.primary,
-                },
-              }}
+              })}
               onClick={onDownload}
               disabled={!showButtons}
             >
@@ -106,17 +99,12 @@ export default function Code(props: CodeProps) {
                 <SvgIcon
                   component={BackIcon}
                   sx={{
-                    stroke: "red",
-                    fill: "white",
-                    color: "red",
-                    transition: "stroke 0.3s, fill 0.3s",
+                    color: "primary",
+                    fill: "transparent",
                   }}
                 />
               }
               color="primary"
-              sx={{
-                mt: 2,
-              }}
               onClick={onBack}
               disabled={!showButtons}
             >
@@ -144,18 +132,13 @@ export default function Code(props: CodeProps) {
                   }}
                 />
               }
-              sx={{
-                mt: 2,
+              sx={(theme: Theme) => ({
                 background: theme.palette.error.main,
-                border: `1px solid ${theme.palette.error.main}`,
+                borderColor: theme.palette.error.main,
                 "&:hover": {
-                  background: "none",
-                  color: theme.palette.error.main,
+                  color: "error.main",
                 },
-                "&:hover .MuiSvgIcon-root path": {
-                  stroke: theme.palette.error.main,
-                },
-              }}
+              })}
               onClick={onReset}
               disabled={!showButtons}
             >

--- a/apps/roboshield/src/components/Statistics/Statistics.tsx
+++ b/apps/roboshield/src/components/Statistics/Statistics.tsx
@@ -37,7 +37,7 @@ export default function Statistics({ title, statistics }: StatiscticsProps) {
         )}
         <Grid container rowSpacing={10} justifyContent="space-between">
           {statistics?.map((statistic) => (
-            <Grid item key={statistic.name}>
+            <Grid item key={statistic.name} xs={12} md={4}>
               <StatisticCard {...statistic} />
             </Grid>
           ))}

--- a/apps/roboshield/src/theme/index.ts
+++ b/apps/roboshield/src/theme/index.ts
@@ -462,7 +462,7 @@ deepmerge(
       textTransform: "uppercase",
     },
   } as any,
-  { clone: false }
+  { clone: false },
 );
 
 deepmerge(
@@ -574,7 +574,7 @@ deepmerge(
       },
     },
   } as ThemeOptions,
-  { clone: false }
+  { clone: false },
 );
 
 export default theme;

--- a/apps/roboshield/src/theme/index.ts
+++ b/apps/roboshield/src/theme/index.ts
@@ -462,7 +462,7 @@ deepmerge(
       textTransform: "uppercase",
     },
   } as any,
-  { clone: false },
+  { clone: false }
 );
 
 deepmerge(
@@ -574,7 +574,7 @@ deepmerge(
       },
     },
   } as ThemeOptions,
-  { clone: false },
+  { clone: false }
 );
 
 export default theme;


### PR DESCRIPTION
## Description

This improves the styling of the RoboShield application. It fixes the responsive behaviour of the About Page and Adds Icons to Action Buttons on the robots.txt generator form.

  
Fixes #761 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

Before:
![Before](https://github.com/user-attachments/assets/83b2ebf0-c93e-4b0d-85d4-785dae0931ad)

After
![After_](https://github.com/user-attachments/assets/21e8bd36-6930-428d-bb17-2f38e415bd56)

<img width="865" alt="Comparison_Buttons" src="https://github.com/user-attachments/assets/2024107c-2614-419c-9c86-667970d8286d">


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
