### PR TITLE
Bump charterafrica version to 0.1.30

### DIFF
--- a/apps/charterafrica/contrib/dokku/Dockerfile
+++ b/apps/charterafrica/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/charterafrica-ui:0.1.29
+FROM codeforafrica/charterafrica-ui:0.1.30

--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "charterafrica",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the official code for https://charter.africa site",

--- a/apps/charterafrica/src/components/Spotlight/Spotlight.js
+++ b/apps/charterafrica/src/components/Spotlight/Spotlight.js
@@ -73,7 +73,7 @@ const Spotlight = React.forwardRef(function Spotlight(props, ref) {
                     <CardMedia
                       alt={item.title}
                       component="img"
-                      src={item.image.src}
+                      src={item.image.url}
                       sx={{
                         height: {
                           xs: "auto",

--- a/apps/charterafrica/src/lib/data/common/processPageIndex.js
+++ b/apps/charterafrica/src/lib/data/common/processPageIndex.js
@@ -47,11 +47,12 @@ const processSpotlight = (page, api, context) => {
       const { item: itemData, ...rest } = item;
       return {
         ...rest,
+        category: rest?.category || null,
         item: {
           ...itemData,
           image: {
-            src: itemData.image.url,
             alt: itemData.image.alt,
+            url: itemData.image.url,
           },
           date: new Date(itemData.date).toLocaleDateString(locale, {
             year: "numeric",

--- a/apps/charterafrica/src/payload/collections/Media.js
+++ b/apps/charterafrica/src/payload/collections/Media.js
@@ -19,6 +19,14 @@ const Media = {
       required: true,
     },
   ],
+  hooks: {
+    afterRead: [
+      ({ doc }) => ({
+        ...doc,
+        alt: doc.alt || doc.filename,
+      }),
+    ],
+  },
 };
 
 export default Media;

--- a/apps/charterafrica/src/payload/collections/Media.js
+++ b/apps/charterafrica/src/payload/collections/Media.js
@@ -23,7 +23,7 @@ const Media = {
     afterRead: [
       ({ doc }) => ({
         ...doc,
-        alt: doc.alt || doc.filename,
+        alt: doc.alt ?? null,
       }),
     ],
   },


### PR DESCRIPTION


## Description

Images under the section "Southern African Development Community Fact Sheets" section are not showing. It is a minor issue where a component is using `image.src` instead of `image.url`.
 
Also, some images have alt text missing so I added an `afterRead` hook to  default to filename.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/1628d7a1-f4a5-4f40-af18-6ecc27c3677f">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
