### PR TITLE
@hurumap/DonutChart

### DIFF
--- a/apps/climatemappedafrica/src/components/HURUmap/Chart/configureScope.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Chart/configureScope.js
@@ -1,6 +1,5 @@
 import { Scope } from "@hurumap/core";
 
-import DonutChartScope from "./DonutChartScope";
 import LineChartScope from "./LineChartScope";
 import MultiLineChartScope from "./MultiLineChartScope";
 import StackedChartScope from "./StackedChartScope";
@@ -11,7 +10,7 @@ import VerticalStackedChartScope from "./VerticalStackedChartScope";
 import { hurumapArgs } from "@/climatemappedafrica/config";
 import theme from "@/climatemappedafrica/theme";
 
-const { BarChartScope } = Scope;
+const { BarChartScope, DonutChartScope } = Scope;
 
 export default function configureScope(
   indicator,
@@ -42,6 +41,19 @@ export default function configureScope(
     isCompare,
     isMobile,
   ];
+  const donutScopeOptions = {
+    primaryData: indicator?.data,
+    metadata: indicator?.metadata,
+    config: configuration,
+    secondaryData: secondaryIndicator?.data ?? null,
+    primaryParentData: showParent ? indicator?.parentData : [{}],
+    secondaryParentData: showParent ? secondaryIndicator?.parentData : [{}],
+    profileNames,
+    isCompare,
+    isMobile,
+    theme,
+    args: hurumapArgs,
+  };
   switch (chartType) {
     case "line":
       if (configuration?.stacked_field) {
@@ -51,7 +63,7 @@ export default function configureScope(
       }
       break;
     case "donut":
-      vegaSpec = DonutChartScope(...scopeOptions);
+      vegaSpec = DonutChartScope(donutScopeOptions);
       break;
     case "treemap":
       vegaSpec = TreemapChartScope(...scopeOptions);

--- a/apps/pesayetu/src/components/HURUmap/Chart/configureScope.js
+++ b/apps/pesayetu/src/components/HURUmap/Chart/configureScope.js
@@ -1,6 +1,5 @@
 import { Scope } from "@hurumap/core";
 
-import DonutChartScope from "./DonutChartScope";
 import LineChartScope from "./LineChartScope";
 import MultiLineChartScope from "./MultiLineChartScope";
 import StackedChartScope from "./StackedChartScope";
@@ -11,7 +10,7 @@ import VerticalStackedChartScope from "./VerticalStackedChartScope";
 import { hurumapArgs } from "@/pesayetu/config";
 import theme from "@/pesayetu/theme";
 
-const { BarChartScope } = Scope;
+const { BarChartScope, DonutChartScope } = Scope;
 
 export default function configureScope(
   indicator,
@@ -42,6 +41,19 @@ export default function configureScope(
     isCompare,
     isMobile,
   ];
+  const donutScopeOptions = {
+    primaryData: indicator?.data,
+    metadata: indicator?.metadata,
+    config: configuration,
+    secondaryData: secondaryIndicator?.data ?? null,
+    primaryParentData: showParent ? indicator?.parentData : [{}],
+    secondaryParentData: showParent ? secondaryIndicator?.parentData : [{}],
+    profileNames,
+    isCompare,
+    isMobile,
+    theme,
+    args: hurumapArgs,
+  };
   switch (chartType) {
     case "line":
       if (configuration?.stacked_field) {
@@ -51,7 +63,7 @@ export default function configureScope(
       }
       break;
     case "donut":
-      vegaSpec = DonutChartScope(...scopeOptions);
+      vegaSpec = DonutChartScope(donutScopeOptions);
       break;
     case "treemap":
       vegaSpec = TreemapChartScope(...scopeOptions);

--- a/packages/hurumap-core/src/Scope/DonutChartScope.js
+++ b/packages/hurumap-core/src/Scope/DonutChartScope.js
@@ -1,10 +1,8 @@
-import merge from "deepmerge";
+import deepmerge from "deepmerge";
 
 import Scope from "./Scope";
 
-import theme from "@/pesayetu/theme";
-
-export default function DonutChartScope(
+export default function DonutChartScope({
   primaryData,
   metadata,
   config,
@@ -14,7 +12,9 @@ export default function DonutChartScope(
   profileNames,
   isCompare,
   isMobile,
-) {
+  theme,
+  args,
+}) {
   const { primary_group: primaryGroup } = metadata;
 
   const secondaryLegend = isCompare
@@ -30,34 +30,37 @@ export default function DonutChartScope(
       ]
     : [];
 
-  return merge(
-    Scope(
+  const transform = [
+    {
+      type: "formula",
+      expr: "format(datum[datatype[Units]], numberFormat[Units]) + ' ' + datum[mainGroup]",
+      as: "custom_label",
+    },
+    {
+      type: "pie",
+      field: { signal: "datatype[Units]" },
+      startAngle: { signal: "startAngle" },
+      endAngle: { signal: "endAngle" },
+      sort: { signal: "sort" },
+    },
+    {
+      type: "collect",
+      sort: { field: "count", order: "descending" },
+    },
+  ];
+  return deepmerge(
+    Scope({
       primaryData,
       metadata,
       config,
       secondaryData,
       primaryParentData,
       secondaryParentData,
-      "donut",
-      [
-        {
-          type: "formula",
-          expr: "format(datum[datatype[Units]], numberFormat[Units]) + ' ' + datum[mainGroup]",
-          as: "custom_label",
-        },
-        {
-          type: "pie",
-          field: { signal: "datatype[Units]" },
-          startAngle: { signal: "startAngle" },
-          endAngle: { signal: "endAngle" },
-          sort: { signal: "sort" },
-        },
-        {
-          type: "collect",
-          sort: { field: "count", order: "descending" },
-        },
-      ],
-    ),
+      chartType: "donut",
+      transform,
+      theme,
+      args,
+    }),
     {
       height: isMobile && isCompare && secondaryData?.length > 1 ? 380 : 180,
       width: 700,

--- a/packages/hurumap-core/src/Scope/index.js
+++ b/packages/hurumap-core/src/Scope/index.js
@@ -1,7 +1,9 @@
 import BarChartScope from "./BarChartScope";
+import DonutChartScope from "./DonutChartScope";
 import Scope from "./Scope";
 
 export default {
   Scope,
   BarChartScope,
+  DonutChartScope,
 };


### PR DESCRIPTION
## Description
This PR moves BarchartScope to Hurumap-Core.
 [Vega Embed](https://github.com/vega/vega-embed) is not a usual React Component which would have been an ideal candidate to move to @hurumap/core.

Currently, various chart(Barchart, LineChart, DonutChart etc) specs have been grouped in their corresponding scopes with common Scope separated.

This PR exports object Scope from hurumap-core with key value pairs of various charts to be accessed as 
```
import { Scope } from "@hurumap/core";
const { DonutChartScope } = Scope;
```
Fixes # 801

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
