### PR TITLE
[Hotfix] @/civisignalblog analytics

### DIFF
--- a/apps/civicsignalblog/contrib/dokku/Dockerfile
+++ b/apps/civicsignalblog/contrib/dokku/Dockerfile
@@ -1,1 +1,1 @@
-FROM codeforafrica/codeforafrica-ui:0.1.11
+FROM codeforafrica/codeforafrica-ui:0.1.12

--- a/apps/civicsignalblog/package.json
+++ b/apps/civicsignalblog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "civicsignalblog",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the (temporary) CivicSignal blog",

--- a/apps/civicsignalblog/src/lib/data/common/index.js
+++ b/apps/civicsignalblog/src/lib/data/common/index.js
@@ -185,11 +185,13 @@ export async function getPageProps(api, context) {
   }
   const blocks = await blockify(page?.blocks, api, context);
   const siteSettings = await api.findGlobal("settings-site");
+  const { analytics } = siteSettings;
   const navbar = getNavBar(siteSettings);
   const footer = getFooter(siteSettings);
 
   const seo = getPageSeoFromMeta(page, siteSettings);
   return {
+    analytics,
     blocks,
     footer,
     navbar,


### PR DESCRIPTION
## Description

`getServerSideProps` did not return analytics needded to enable GA. This PR addresses that.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![S](https://github.com/user-attachments/assets/fc9055ce-276f-4c37-839f-fc186c207be3)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
