### PR TITLE
@/hurumap: Add configurable geometry border color option for Choropleth map

### DIFF
--- a/packages/hurumap-next/src/Map/utils.js
+++ b/packages/hurumap-next/src/Map/utils.js
@@ -62,7 +62,7 @@ const generateLegend = (
   return legend;
 };
 
-export const generateChoropleth = (colors, locations, mapType) => {
+export const generateChoropleth = (choroplethProps, locations, mapType) => {
   if (mapType !== "choropleth") return null;
 
   const filteredLocations = locations.filter(({ count }) => count !== null);
@@ -75,13 +75,14 @@ export const generateChoropleth = (colors, locations, mapType) => {
   const roundedMaxCount = Math.ceil(maxCount);
 
   const negativeColorRange =
-    colors?.negative_color_range ||
+    choroplethProps?.negative_color_range ||
     defaultChoroplethStyles.negative_color_range;
   const positiveColorRange =
-    colors?.positive_color_range ||
+    choroplethProps?.positive_color_range ||
     defaultChoroplethStyles.positive_color_range;
-  const zeroColor = colors?.zero_color || defaultChoroplethStyles.zero_color;
-  const opacity = colors?.opacity || defaultChoroplethStyles.opacity;
+  const zeroColor =
+    choroplethProps?.zero_color || defaultChoroplethStyles.zero_color;
+  const opacity = choroplethProps?.opacity || defaultChoroplethStyles.opacity;
 
   const positiveThresholds = hasPositiveValues
     ? calculateThresholds(
@@ -125,6 +126,7 @@ export const generateChoropleth = (colors, locations, mapType) => {
       code,
       count,
       fillColor: color,
+      color: choroplethProps.border_color,
       opacity,
     };
   });


### PR DESCRIPTION
## Description
This PR introduces a minor enhancement to the Choropleth map, by adding a configurable geometry border color option.

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## Screenshots

<img width="380" alt="Screenshot 2024-08-28 at 12 07 36 (1)" src="https://github.com/user-attachments/assets/7f652fb7-e9f4-45ff-af25-34237e0ff32b">

<img width="619" alt="Screenshot 2024-08-28 at 12 10 58" src="https://github.com/user-attachments/assets/ef28946e-49d9-4936-83da-d8a1b7c77903">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
