### PR TITLE
@/codeforafrica - fix: Partners form not rendering

### DIFF
--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeforafrica",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the main CFA site.",

--- a/apps/codeforafrica/src/payload/collections/Partners.js
+++ b/apps/codeforafrica/src/payload/collections/Partners.js
@@ -50,7 +50,7 @@ const Partners = {
       name: "description",
       required: true,
       localized: true,
-      editor: slateEditor(),
+      editor: slateEditor({}),
     }),
     socialLinks({
       name: "connect",


### PR DESCRIPTION
## Description
This PR resolves an issue in the `codeforafrica` CMS where the Partners collection form fails to render. The issue is fixed by passing an empty object `{}` as a parameter when calling `slateEditor`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots
<img width="795" alt="Screenshot 2024-09-12 at 09 34 32" src="https://github.com/user-attachments/assets/75cb5b03-83a1-430c-aad6-cbf321d19af0">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
