### PR TITLE
@/civicsignalblog 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -403,8 +403,12 @@ ENV NEXT_PUBLIC_APP_LOGO_URL=${NEXT_PUBLIC_APP_LOGO_URL} \
 
 RUN set -ex \
   # Create nextjs cache dir w/ correct permissions
-  && mkdir -p ./apps/civicsignalblog//.next \
+  && mkdir -p ./apps/civicsignalblog/.next \
   && chown nextjs:nodejs ./apps/civicsignalblog/.next
+
+# Node
+# Subpath imports definitions
+COPY --from=civicsignalblog-builder --chown=nextjs:nodejs /workspace/apps/civicsignalblog/package.json ./apps/civicsignalblog/package.json
 
 # PNPM
 # symlink some dependencies
@@ -424,8 +428,8 @@ COPY --from=civicsignalblog-builder --chown=nextjs:nodejs /workspace/apps/civics
 COPY --from=civicsignalblog-builder --chown=nextjs:nodejs /workspace/apps/civicsignalblog/.next ./apps/civicsignalblog/.next
 
 # Payload
-COPY --from=civicsignalblog-builder /workspace/apps/civicsignalblog/dist ./apps/civicsignalblog/dist
-COPY --from=civicsignalblog-builder /workspace/apps/civicsignalblog/build ./apps/civicsignalblog/build
+COPY --from=civicsignalblog-builder --chown=nextjs:nodejs /workspace/apps/civicsignalblog/dist ./apps/civicsignalblog/dist
+COPY --from=civicsignalblog-builder --chown=nextjs:nodejs /workspace/apps/civicsignalblog/build ./apps/civicsignalblog/build
 
 # Since we can't use output: "standalone", switch to specific app's folder
 WORKDIR /workspace/apps/civicsignalblog


### PR DESCRIPTION
## Description

[Subpath imports](https://nodejs.org/docs/latest-v20.x/api/packages.html#subpath-imports) requires `package.json` to be present when running the app in PROD.

## Type of change

Please delete options that are not relevant.

- [x] Chore

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
