### PR TITLE
Fix ClimateMapped build public URL

### DIFF
--- a/.github/workflows/climatemappedafrica-deploy-dev.yml
+++ b/.github/workflows/climatemappedafrica-deploy-dev.yml
@@ -56,6 +56,7 @@ jobs:
           build-args: |
             HURUMAP_API_URL=${{ secrets.CLIMATEMAPPEDAFRICA_HURUMAP_API_URL }}
             MONGO_URL=${{ secrets.CLIMATEMAPPEDAFRICA_MONGO_URL }}
+            NEXT_PUBLIC_APP_URL=${{ env.NEXT_PUBLIC_APP_URL }}
             PAYLOAD_SECRET=${{ secrets.CLIMATEMAPPEDAFRICA_PAYLOAD_SECRET }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new

--- a/apps/climatemappedafrica/package.json
+++ b/apps/climatemappedafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climatemappedafrica",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "Climate Mapped Africa ",


### PR DESCRIPTION
## Description
The `NEXT_PUBLIC_URL` wad defined but was not used when building the image. This causes a CORS error when accessing PayloadCMS. This issue fixes this bug

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
