### PR TITLE
@/CivicSignalBlog - fix eslint failure due to custom Payload components

### DIFF
--- a/apps/civicsignalblog/.eslintrc.js
+++ b/apps/civicsignalblog/.eslintrc.js
@@ -3,6 +3,15 @@ module.exports = {
   extends: ["eslint-config-commons-ui/next"],
   rules: {
     "react/jsx-filename-extension": [1, { extensions: [".js", ".tsx"] }], // This rule allows JSX syntax in both .js and tsx files
+    // Disable requirement for importing file extensions for js and tsx files, without this we cant import custom components in Payload
+    "import/extensions": [
+      "error",
+      "ignorePackages",
+      {
+        js: "never",
+        tsx: "never",
+      },
+    ],
   },
   settings: {
     "import/resolver": {

--- a/apps/civicsignalblog/jest.config.js
+++ b/apps/civicsignalblog/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
       "<rootDir>/../../packages/commons-ui-core/src/$1",
     "^@/commons-ui/next/(.*)$":
       "<rootDir>/../../packages/commons-ui-next/src/$1",
+    "^@/commons-ui/payload/(.*)$":
+      "<rootDir>/../../packages/commons-ui-payload/src/$1",
   },
   transformIgnorePatterns: ["<rootDir>/node_modules/(?!camelcase-keys)"],
 };

--- a/apps/civicsignalblog/src/components/PageHeader/PageHeader.snap.js
+++ b/apps/civicsignalblog/src/components/PageHeader/PageHeader.snap.js
@@ -15,9 +15,10 @@ exports[`<PageHeader /> renders unchanged 1`] = `
       </h2>
       <div
         class="MuiBox-root css-0"
+        typographyprops="[object Object]"
       >
-        <h2
-          class="MuiTypography-root MuiTypography-h2 css-hd3436-MuiTypography-root"
+        <p
+          class="MuiTypography-root MuiTypography-body1 css-oo170e-MuiTypography-root"
         >
           Let's
           <strong>
@@ -27,7 +28,7 @@ exports[`<PageHeader /> renders unchanged 1`] = `
           <strong>
              together
           </strong>
-        </h2>
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Description

Currently eslint is failing due to missing extensions for tsx files. This PR addresses this issue by adding [import/resolve](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/extensions.md) to **never** require extensions when importing js and tsx files.

Additionally, an update was done on `jest.config.js` to allow resolving of packages in `@/commons-ui/payload`

Fixes #972 

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
