### PR TITLE
Fix @/climatemappedafrica images on Dev

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,3 +10,4 @@ README.md
 **/.turbo
 **/.vscode
 **/build
+**/media

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,7 @@ storybook-static
 
 mongo-keyfile
 
-#Google credentials
+# Google credentials
 credentials.json
 
 # Sentry Config File
@@ -67,3 +67,6 @@ credentials.json
 # SQLite files
 **.db
 **.sqlite
+
+# Payload media folder
+media

--- a/apps/climatemappedafrica/.env.template
+++ b/apps/climatemappedafrica/.env.template
@@ -17,7 +17,7 @@ NEXT_PUBLIC_OPENAFRICA_DOMAINS=
 # based site domain)
 NEXT_PUBLIC_SOURCEAFRICA_DOMAINS=
 
-#Analytics
+# Google Analytics
 NEXT_PUBLIC_GOOGLE_ANALYTICS_ID = "G-xxxxxxxx"
 
 # AWS S3 bucket for storing images
@@ -26,10 +26,10 @@ S3_SECRET_ACCESS_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 S3_BUCKET=name-of-s3-bucket
 S3_REGION=bucket-region-us-east-1
 
-#
+# Payload
 MONGO_URL="mongodb+srv://<user>:<pass>@host/db"
 PAYLOAD_PUBLIC_APP_URL="http://localhost:3000"
 PAYLOAD_SECRET="secure random string"
 
-# HURUmap URL
+# HURUmap
 HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"

--- a/apps/climatemappedafrica/.env.template
+++ b/apps/climatemappedafrica/.env.template
@@ -1,12 +1,4 @@
-# Learn more about ENV variables at https://github.com/WebDevStudios/nextjs-wordpress-starter/wiki/env-variables
-
-# Tells Next.js we're in development mode. You do not need a Vercel account for this.
-VERCEL_ENV="development"
-
-NEXT_PUBLIC_APP_URL = 'http://localhost:3000'
-
-# Allows Node to work with local, self-signed certificates.
-NODE_TLS_REJECT_UNAUTHORIZED="0"
+NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
 # The domain where your images are hosted on.
 # See https://nextjs.org/docs/basic-features/image-optimization#domains
@@ -15,9 +7,6 @@ NEXT_PUBLIC_IMAGE_DOMAINS="cms.dev.codeforafrica.org"
 # How to scale downloaded/shared images (width and height)
 # See https://vega.github.io/vega/docs/api/view/#view_toImageURL
 NEXT_PUBLIC_IMAGE_SCALE_FACTOR=2
-
-# HURUmap URL
-HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"
 
 # openAFRICA domains
 # A comma-separated list of domains to openAFRICA (or any CKAN-based site domain)
@@ -28,11 +17,19 @@ NEXT_PUBLIC_OPENAFRICA_DOMAINS=
 # based site domain)
 NEXT_PUBLIC_SOURCEAFRICA_DOMAINS=
 
-# AWS S3 bucket for storing images
-S3_UPLOAD_KEY=AAAAAAAAAAAAAAAAAAAA
-S3_UPLOAD_SECRET=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
-S3_UPLOAD_BUCKET=name-of-s3-bucket
-S3_UPLOAD_REGION=bucket-region-us-east-1
-
 #Analytics
 NEXT_PUBLIC_GOOGLE_ANALYTICS_ID = "G-xxxxxxxx"
+
+# AWS S3 bucket for storing images
+S3_ACCESS_KEY_ID=AAAAAAAAAAAAAAAAAAAA
+S3_SECRET_ACCESS_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+S3_BUCKET=name-of-s3-bucket
+S3_REGION=bucket-region-us-east-1
+
+#
+MONGO_URL="mongodb+srv://<user>:<pass>@host/db"
+PAYLOAD_PUBLIC_APP_URL="http://localhost:3000"
+PAYLOAD_SECRET="secure random string"
+
+# HURUmap URL
+HURUMAP_API_URL="https://ng.hurumap.org/api/v1/"

--- a/apps/climatemappedafrica/next.config.js
+++ b/apps/climatemappedafrica/next.config.js
@@ -13,6 +13,8 @@ module.exports = {
     domains: process.env.NEXT_PUBLIC_IMAGE_DOMAINS?.split(",")
       ?.map((d) => d.trim())
       ?.filter((d) => d),
+    loader: "custom",
+    loaderFile: "./payload.image.loader.js",
     unoptimized:
       process.env.NEXT_PUBLIC_IMAGE_UNOPTIMIZED?.trim()?.toLowerCase() ===
       "true",

--- a/apps/climatemappedafrica/payload.config.ts
+++ b/apps/climatemappedafrica/payload.config.ts
@@ -73,12 +73,12 @@ export default buildConfig({
   globals: [HURUMap, Site] as GlobalConfig[],
   ...(locales?.length
     ? {
-      localization: {
-        locales,
-        defaultLocale,
-        fallback: true,
-      },
-    }
+        localization: {
+          locales,
+          defaultLocale,
+          fallback: true,
+        },
+      }
     : undefined),
   admin: {
     webpack: (config) => ({

--- a/apps/climatemappedafrica/payload.config.ts
+++ b/apps/climatemappedafrica/payload.config.ts
@@ -34,12 +34,16 @@ const csrf =
     ?.map((d) => d.trim())
     ?.filter(Boolean) ?? [];
 
-const adapter = s3Adapter({
+const accessKeyId = process?.env?.S3_ACCESS_KEY_ID;
+const secretAccessKey = process?.env?.S3_SECRET_ACCESS_KEY;
+const enableCloudStorage = Boolean(accessKeyId && secretAccessKey);
+
+const cloudStorageAdapter = s3Adapter({
   config: {
     region: process?.env?.S3_REGION,
     credentials: {
-      accessKeyId: process?.env?.S3_ACCESS_KEY_ID,
-      secretAccessKey: process?.env?.S3_SECRET_ACCESS_KEY,
+      accessKeyId,
+      secretAccessKey,
     },
   },
   bucket: process?.env?.S3_BUCKET,
@@ -69,12 +73,12 @@ export default buildConfig({
   globals: [HURUMap, Site] as GlobalConfig[],
   ...(locales?.length
     ? {
-        localization: {
-          locales,
-          defaultLocale,
-          fallback: true,
-        },
-      }
+      localization: {
+        locales,
+        defaultLocale,
+        fallback: true,
+      },
+    }
     : undefined),
   admin: {
     webpack: (config) => ({
@@ -106,11 +110,11 @@ export default buildConfig({
   },
   plugins: [
     cloudStorage({
+      enabled: enableCloudStorage,
       collections: {
         media: {
-          adapter,
-          // TODO(kilemensi): Toogle this depending on ENV?
-          disableLocalStorage: false,
+          adapter: cloudStorageAdapter,
+          disableLocalStorage: enableCloudStorage,
           prefix: "media",
         },
       },

--- a/apps/climatemappedafrica/payload.image.loader.js
+++ b/apps/climatemappedafrica/payload.image.loader.js
@@ -1,0 +1,11 @@
+"use client";
+
+import site from "@/climatemappedafrica/utils/site";
+
+export default function payloadImageLoader({ src }) {
+  // Handle relative paths (/media) only
+  if (src?.startsWith("/media")) {
+    return `${site.url}${src}`;
+  }
+  return src;
+}

--- a/apps/climatemappedafrica/src/components/HURUmap/LocationHeader/useStyles.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/LocationHeader/useStyles.js
@@ -1,9 +1,12 @@
 import makeStyles from "@mui/styles/makeStyles";
 
-const useStyles = makeStyles(({ typography, palette }) => ({
+const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
   root: {
     borderBottom: `solid 1px ${palette.divider}`,
     paddingTop: typography.pxToRem(20),
+    [breakpoints.up("lg")]: {
+      position: "relative",
+    },
   },
   titleContent: {
     display: "flex",
@@ -33,6 +36,10 @@ const useStyles = makeStyles(({ typography, palette }) => ({
     height: typography.pxToRem(44),
     minWidth: typography.pxToRem(44),
     boxShadow: "none",
+    [breakpoints.up("lg")]: {
+      // quick fix to ensure print button aligns with rich data/pin buttons
+      marginTop: "10px",
+    },
   },
   closeButton: {
     marginLeft: typography.pxToRem(20),

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/PanelButtons.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/PanelButtons.js
@@ -139,7 +139,8 @@ function PanelButtons({
         }),
         ({ widths }) =>
           open && {
-            left: `max(calc((100vw - ${widths.values.lg}px)/2 + 833px),1100px)`,
+            // must match min width of TreeView + Profile
+            left: `max(calc((100vw - ${widths.values.lg}px)/2 + 79px + 800px),1100px)`,
           },
       ]}
     />

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/MobilePanel/MobilePanel.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/MobilePanel/MobilePanel.js
@@ -4,7 +4,7 @@ import React from "react";
 
 import RichData from "./RichData";
 
-import PrintIcon from "@/climatemappedafrica/assets/icons/print.svg";
+import PrintIcon from "@/climatemappedafrica/assets/icons/print.svg?url";
 import TopIcon from "@/climatemappedafrica/assets/icons/top.svg";
 import LocationHeader from "@/climatemappedafrica/components/HURUmap/LocationHeader";
 import PinAndCompare from "@/climatemappedafrica/components/HURUmap/PinAndCompare";

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/MobilePanel/MobilePanel.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/MobilePanel/MobilePanel.js
@@ -4,7 +4,7 @@ import React from "react";
 
 import RichData from "./RichData";
 
-import PrintIcon from "@/climatemappedafrica/assets/icons/print.svg?url";
+import printIcon from "@/climatemappedafrica/assets/icons/print.svg?url";
 import TopIcon from "@/climatemappedafrica/assets/icons/top.svg";
 import LocationHeader from "@/climatemappedafrica/components/HURUmap/LocationHeader";
 import PinAndCompare from "@/climatemappedafrica/components/HURUmap/PinAndCompare";
@@ -52,7 +52,7 @@ function MobilePanel({ activeType, scrollToTopLabel, sx, ...props }) {
         <Section>
           <LocationHeader
             variant="primary"
-            icon={PrintIcon}
+            icon={printIcon}
             title={geography.name}
             {...geography}
           />

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
@@ -85,11 +85,15 @@ const Profile = forwardRef(function Profile(
   return (
     <Box
       sx={[
-        ({ palette, typography, zIndex }) => ({
+        ({ palette, typography, widths, zIndex }) => ({
           backgroundColor: palette.background.default,
+          // must match min width of TreeView
+          left: {
+            lg: `max(calc((100vw - ${widths.values.lg}px)/2 + 79px), 300px)`,
+          },
           marginLeft: {
             xs: typography.pxToRem(20),
-            lg: `max(calc((100vw - 1160px)/2 + 79px), 300px)`,
+            lg: 0,
           },
           marginRight: {
             xs: typography.pxToRem(20),
@@ -104,10 +108,11 @@ const Profile = forwardRef(function Profile(
             md: typography.pxToRem(80),
             lg: typography.pxToRem(17),
           },
-          width: { lg: typography.pxToRem(800) },
-          minHeight: { lg: "100%" },
           paddingTop: { lg: typography.pxToRem(67.7) },
           paddingRight: { lg: typography.pxToRem(17) },
+          position: { lg: "absolute" },
+          width: { lg: typography.pxToRem(800) },
+          minHeight: { lg: "100%" },
           zIndex: { lg: zIndex.drawer },
         }),
         ...(Array.isArray(sx) ? sx : [sx]),

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 
 import ProfileItems from "./ProfileItems";
 
-import Print from "@/climatemappedafrica/assets/icons/print.svg?url";
+import printIcon from "@/climatemappedafrica/assets/icons/print.svg?url";
 import LocationHeader from "@/climatemappedafrica/components/HURUmap/LocationHeader";
 import PinAndCompare from "@/climatemappedafrica/components/HURUmap/PinAndCompare";
 import Loading from "@/climatemappedafrica/components/Loading";
@@ -122,7 +122,7 @@ const Profile = forwardRef(function Profile(
       {isLoading && <Loading />}
       <LocationHeader
         variant="primary"
-        icon={Print}
+        icon={printIcon}
         title={primaryProfile.geography.name}
         onClick={handleClick(primaryProfile)}
         {...primaryProfile.geography}

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/Profile.js
@@ -4,7 +4,7 @@ import React, { forwardRef } from "react";
 
 import ProfileItems from "./ProfileItems";
 
-import Print from "@/climatemappedafrica/assets/icons/print.svg";
+import Print from "@/climatemappedafrica/assets/icons/print.svg?url";
 import LocationHeader from "@/climatemappedafrica/components/HURUmap/LocationHeader";
 import PinAndCompare from "@/climatemappedafrica/components/HURUmap/PinAndCompare";
 import Loading from "@/climatemappedafrica/components/Loading";

--- a/apps/climatemappedafrica/src/pages/[[...slugs]].js
+++ b/apps/climatemappedafrica/src/pages/[[...slugs]].js
@@ -51,11 +51,15 @@ function Index({ blocks, menus, footer: footerProps, seo = {}, fallback }) {
     }
   }
 
-  const tutorialBlock = blocks.find((block) => block.blockType === "tutorial");
-
   let TutorialComponent = React.Fragment;
+  let TutorialComponentProps;
+  const tutorialBlock = blocks.find((block) => block.blockType === "tutorial");
   if (tutorialBlock) {
     TutorialComponent = Tutorial;
+    TutorialComponentProps = {
+      ...tutorialBlock,
+      defaultOpen: Number.parseInt(showTutorial, 10) === 1,
+    };
   }
 
   let PageConfig = React.Fragment;
@@ -65,11 +69,7 @@ function Index({ blocks, menus, footer: footerProps, seo = {}, fallback }) {
     pageConfigProps = { value: { fallback } };
   }
   return (
-    <TutorialComponent
-      key={showTutorial}
-      {...tutorialBlock}
-      defaultOpen={Number.parseInt(showTutorial, 10) === 1}
-    >
+    <TutorialComponent key={showTutorial} {...TutorialComponentProps}>
       <Navigation {...menus} />
       <NextSeo
         {...pageSeo}

--- a/apps/climatemappedafrica/src/payload/blocks/Hero.js
+++ b/apps/climatemappedafrica/src/payload/blocks/Hero.js
@@ -1,3 +1,5 @@
+import { slateEditor } from "@payloadcms/richtext-slate";
+
 import richText from "../fields/richText";
 
 const Hero = {
@@ -12,13 +14,24 @@ const Hero = {
     richText({
       name: "title",
       required: true,
-      label: "Title",
       localized: true,
+      editor: slateEditor({
+        admin: {
+          elements: [],
+          leaves: ["bold"],
+        },
+      }),
     }),
     richText({
       name: "subtitle",
       required: true,
       localized: true,
+      editor: slateEditor({
+        admin: {
+          elements: [],
+          leaves: ["bold", "code", "italic", "strikethrough", "underline"],
+        },
+      }),
     }),
     {
       name: "searchLabel",


### PR DESCRIPTION
## Description

Main fix is adding a custom loader that will delegate loading of images coming from CMS (`/media`) to payload directly rather than via Next.js which may fail in weird ways (e.g. Next.js tries to load them via `/_next/image?url=`). The PR also:

  - [x] Improves the local/S3 image handling: If S3 key and secret are found, S3 is used. Otherwise, local media folder is used
  - [x] Fixes the print icon on explore page
  - [x] Ensure the panel in desktop mode scales well for screens that are lg+ i.e. the rich data/pin icons move accordingly.
  - [x] Ensure `TotorialComponentProps` exist when there is an `tutorial` block only.

PS: Lets test the image loading S3/local well to make sure we've fixed it once and for all.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

<img width="847" alt="Screenshot 2024-10-25 at 14 55 32" src="https://github.com/user-attachments/assets/2000d688-4fc0-4971-ae70-ddbc2854a503">

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
