### PR TITLE
@/climatemappedafrica Hero page map colour codes

### DIFF
--- a/apps/climatemappedafrica/src/components/Hero/Hero.js
+++ b/apps/climatemappedafrica/src/components/Hero/Hero.js
@@ -4,6 +4,8 @@ import dynamic from "next/dynamic";
 import PropTypes from "prop-types";
 import React, { useState } from "react";
 
+import Legend from "./Legend";
+
 import heroBg from "@/climatemappedafrica/assets/images/bg-map-white.jpg";
 import DropdownSearch from "@/climatemappedafrica/components/DropdownSearch";
 import Image from "@/climatemappedafrica/components/Image";
@@ -23,6 +25,8 @@ function Hero({
   properties,
   level,
   explorePageSlug,
+  averageTemperature,
+  legend,
   ...props
 }) {
   const isUpLg = useMediaQuery((theme) => theme.breakpoints.up("lg"));
@@ -99,45 +103,44 @@ function Hero({
             </RichTypography>
           </Grid>
           {/* Since map is dynamic-ally loaded, no need for implementation="css" */}
-          <Box
-            sx={{
-              display: {
-                xs: "none",
-                md: "block",
-              },
-            }}
-          >
-            <Grid item md={5}>
-              {center ? (
-                <Map
-                  center={[center[1], center[0]]}
-                  zoom={zoom}
-                  tileLayer={{
-                    url: "https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png",
-                  }}
-                  onLayerMouseOver={setHoverGeo}
-                  featuredLocations={featuredLocations}
-                  explorePageSlug={explorePageSlug}
-                  {...props}
-                />
-              ) : null}
-              <Box sx={{ height: 80 }}>
-                <RichTypography
-                  variant="h6"
-                  sx={{
-                    lineHeight: 23 / 18,
-                    lineSpacing: "0.9px",
-                    fontWeight: "normal",
-                    textTransform: "capitalize",
-                    display: "flex",
-                    justifyContent: "flex-end",
-                  }}
-                >
-                  {hoverGeo}
-                </RichTypography>
-              </Box>
-            </Grid>
-          </Box>
+
+          <Grid item md={6} xs={12} justifyContent="center">
+            {center ? (
+              <Map
+                center={[center[1], center[0]]}
+                zoom={zoom}
+                tileLayer={{
+                  url: "https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png",
+                }}
+                onLayerMouseOver={setHoverGeo}
+                featuredLocations={featuredLocations}
+                explorePageSlug={explorePageSlug}
+                {...props}
+              />
+            ) : null}
+            <Box
+              display="flex"
+              justifyContent="space-between"
+              alignItems="center"
+              gap={2}
+              sx={{ height: 80, width: "100%" }}
+            >
+              <Legend title={averageTemperature} data={legend} />
+              <RichTypography
+                variant="h6"
+                sx={{
+                  lineHeight: 23 / 18,
+                  lineSpacing: "0.9px",
+                  fontWeight: "normal",
+                  textTransform: "capitalize",
+                  display: "flex",
+                  justifyContent: "flex-end",
+                }}
+              >
+                {hoverGeo}
+              </RichTypography>
+            </Box>
+          </Grid>
         </Grid>
       </Section>
     </Box>
@@ -154,6 +157,7 @@ Hero.propTypes = {
   properties: PropTypes.shape({}),
   level: PropTypes.string,
   explorePageSlug: PropTypes.string,
+  averageTemperature: PropTypes.string,
 };
 
 export default Hero;

--- a/apps/climatemappedafrica/src/components/Hero/Hero.js
+++ b/apps/climatemappedafrica/src/components/Hero/Hero.js
@@ -104,7 +104,7 @@ function Hero({
           </Grid>
           {/* Since map is dynamic-ally loaded, no need for implementation="css" */}
 
-          <Grid item md={6} xs={12} justifyContent="center">
+          <Grid item md={6} xs={12} justifyContent="flex-end">
             {center ? (
               <Map
                 center={[center[1], center[0]]}

--- a/apps/climatemappedafrica/src/components/Hero/Hero.snap.js
+++ b/apps/climatemappedafrica/src/components/Hero/Hero.snap.js
@@ -90,7 +90,7 @@ exports[`<Hero /> renders unchanged 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1uu4n02-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-g8r332-MuiGrid-root"
         >
           <div
             class="MuiBox-root css-ljsg2c"
@@ -102,39 +102,25 @@ exports[`<Hero /> renders unchanged 1`] = `
                 class="MuiBox-root css-70qvj9"
               >
                 <div
-                  aria-label="10 - 13"
                   class="MuiBox-root css-1wok3bd"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="13 - 16"
                   class="MuiBox-root css-1fg12k3"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="16 - 19"
                   class="MuiBox-root css-55biq3"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="19 - 22"
                   class="MuiBox-root css-9qafv7"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="22 - 25"
                   class="MuiBox-root css-5srxm6"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="25 - 28"
                   class="MuiBox-root css-1kw6r8l"
-                  data-mui-internal-clone-element="true"
                 />
                 <div
-                  aria-label="28 - 31"
                   class="MuiBox-root css-oi5eih"
-                  data-mui-internal-clone-element="true"
                 />
               </div>
             </div>

--- a/apps/climatemappedafrica/src/components/Hero/Hero.snap.js
+++ b/apps/climatemappedafrica/src/components/Hero/Hero.snap.js
@@ -90,14 +90,54 @@ exports[`<Hero /> renders unchanged 1`] = `
           </div>
         </div>
         <div
-          class="MuiBox-root css-h9r63z"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1uu4n02-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-5 css-1f9gci5-MuiGrid-root"
+            class="MuiBox-root css-ljsg2c"
           >
             <div
-              class="MuiBox-root css-4tnojn"
-            />
+              class="MuiBox-root css-0"
+            >
+              <div
+                class="MuiBox-root css-70qvj9"
+              >
+                <div
+                  aria-label="10 - 13"
+                  class="MuiBox-root css-1wok3bd"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="13 - 16"
+                  class="MuiBox-root css-1fg12k3"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="16 - 19"
+                  class="MuiBox-root css-55biq3"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="19 - 22"
+                  class="MuiBox-root css-9qafv7"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="22 - 25"
+                  class="MuiBox-root css-5srxm6"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="25 - 28"
+                  class="MuiBox-root css-1kw6r8l"
+                  data-mui-internal-clone-element="true"
+                />
+                <div
+                  aria-label="28 - 31"
+                  class="MuiBox-root css-oi5eih"
+                  data-mui-internal-clone-element="true"
+                />
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/climatemappedafrica/src/components/Hero/Hero.test.js
+++ b/apps/climatemappedafrica/src/components/Hero/Hero.test.js
@@ -48,6 +48,15 @@ const defaultProps = {
   },
   variant: "explore",
   icon: null,
+  legend: [
+    { min: 10, max: 13, color: "#021AFE" },
+    { min: 13, max: 16, color: "#5455FF" },
+    { min: 16, max: 19, color: "#928EFD" },
+    { min: 19, max: 22, color: "#B494DF" },
+    { min: 22, max: 25, color: "#FA9B9B" },
+    { min: 25, max: 28, color: "#F96264" },
+    { min: 28, max: 31, color: "#F80701" },
+  ],
 };
 
 describe("<Hero />", () => {

--- a/apps/climatemappedafrica/src/components/Hero/Legend.js
+++ b/apps/climatemappedafrica/src/components/Hero/Legend.js
@@ -1,0 +1,65 @@
+import { RichTypography } from "@commons-ui/legacy";
+import { Box, Tooltip } from "@mui/material";
+import PropTypes from "prop-types";
+import React, { useState, forwardRef } from "react";
+
+const Legend = forwardRef(function Legend({ data, title }, ref) {
+  const [hoveredValue, setHoveredValue] = useState(null);
+
+  const handleMouseEnter = (value) => {
+    setHoveredValue(value);
+  };
+
+  const handleMouseLeave = () => {
+    setHoveredValue(null);
+  };
+
+  return (
+    <Box>
+      <RichTypography variant="caption" sx={{ fontWeight: "bold", mb: 1 }}>
+        {title}
+      </RichTypography>
+      <Box ref={ref} display="flex" alignItems="center">
+        {data.map((item) => (
+          <Tooltip
+            key={`${item.min} - ${item.max}`}
+            title={`${item.min} - ${item.max}`}
+            placement="top"
+            arrow
+          >
+            <Box
+              onMouseEnter={() => handleMouseEnter(`${item.min} - ${item.max}`)}
+              onMouseLeave={handleMouseLeave}
+              sx={{
+                backgroundColor: item.color,
+                height: 24,
+                minWidth: 24,
+                cursor: "pointer",
+              }}
+            />
+          </Tooltip>
+        ))}
+        {hoveredValue && (
+          <RichTypography
+            variant="caption"
+            sx={{ marginLeft: 2, whiteSpace: "nowrap" }}
+          >
+            {hoveredValue}
+          </RichTypography>
+        )}
+      </Box>
+    </Box>
+  );
+});
+
+Legend.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      min: PropTypes.number.isRequired,
+      max: PropTypes.number.isRequired,
+      color: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+};
+
+export default Legend;

--- a/apps/climatemappedafrica/src/components/Hero/Legend.js
+++ b/apps/climatemappedafrica/src/components/Hero/Legend.js
@@ -1,5 +1,5 @@
 import { RichTypography } from "@commons-ui/legacy";
-import { Box, Tooltip } from "@mui/material";
+import { Box } from "@mui/material";
 import PropTypes from "prop-types";
 import React, { useState, forwardRef } from "react";
 
@@ -21,23 +21,17 @@ const Legend = forwardRef(function Legend({ data, title }, ref) {
       </RichTypography>
       <Box ref={ref} display="flex" alignItems="center">
         {data.map((item) => (
-          <Tooltip
+          <Box
             key={`${item.min} - ${item.max}`}
-            title={`${item.min} - ${item.max}`}
-            placement="top"
-            arrow
-          >
-            <Box
-              onMouseEnter={() => handleMouseEnter(`${item.min} - ${item.max}`)}
-              onMouseLeave={handleMouseLeave}
-              sx={{
-                backgroundColor: item.color,
-                height: 24,
-                minWidth: 24,
-                cursor: "pointer",
-              }}
-            />
-          </Tooltip>
+            onMouseEnter={() => handleMouseEnter(`${item.min} - ${item.max}`)}
+            onMouseLeave={handleMouseLeave}
+            sx={{
+              backgroundColor: item.color,
+              height: 24,
+              minWidth: 24,
+              cursor: "pointer",
+            }}
+          />
         ))}
         {hoveredValue && (
           <RichTypography

--- a/apps/climatemappedafrica/src/components/Hero/Map.js
+++ b/apps/climatemappedafrica/src/components/Hero/Map.js
@@ -23,19 +23,23 @@ function Map({
   onLayerMouseOver,
   featuredLocations,
   explorePageSlug,
+  choropleth,
 }) {
   const router = useRouter();
 
-  const countyCodes = featuredLocations?.map(({ code }) => code);
-
+  const regionCodes = featuredLocations?.map(({ code }) => code);
   const theme = useTheme();
   const onEachFeature = (feature, layer) => {
+    const choroplethColor = choropleth?.find?.(
+      (c) => c.code.toLowerCase() === feature.properties.code.toLowerCase(),
+    );
     layer.setStyle({
       fillColor: theme.palette.background.default,
+      ...choroplethColor,
       fillOpacity: 1,
     });
 
-    if (countyCodes.includes(feature.properties.code?.toLowerCase())) {
+    if (regionCodes.includes(feature.properties.code?.toLowerCase())) {
       layer.setStyle({
         weight: 1.5,
         dashArray: 0,
@@ -51,10 +55,7 @@ function Map({
       });
       layer.on("mouseout", () => {
         onLayerMouseOver(null);
-        layer.setStyle({
-          fillOpacity: 1,
-          fillColor: theme.palette.background.default,
-        });
+        layer.setStyle({ ...choroplethColor, fillOpacity: 1 });
       });
       layer.on("click", () => {
         if (explorePageSlug) {
@@ -67,36 +68,38 @@ function Map({
   };
 
   return (
-    <Box
-      sx={{
-        position: "relative",
-        height: { sm: "350px", lg: "471px" },
-        width: { sm: "300px", lg: "500px" },
-        marginTop: { sm: "55px", lg: "42px" },
-        "& .leaflet-container": {
-          background: "transparent",
-        },
-      }}
-    >
-      <MapContainer
-        center={center}
-        zoom={zoom}
-        boxZoom={false}
-        dragging={false}
-        doubleClickZoom={false}
-        zoomControl={false}
-        scrollWheelZoom={false}
-        touchZoom={false}
-        trackResize={false}
-        zoomSnap={0.25}
-        style={styles}
+    <Box display="flex" justifyContent="center">
+      <Box
+        sx={{
+          position: "relative",
+          height: { sm: "350px", lg: "471px" },
+          width: { xs: "100%", sm: "300px", lg: "500px" },
+          marginTop: { sm: "55px", lg: "42px" },
+          "& .leaflet-container": {
+            background: "transparent",
+          },
+        }}
       >
-        <GeoJSON
-          data={boundary}
-          style={geoJSONStyles}
-          onEachFeature={onEachFeature}
-        />
-      </MapContainer>
+        <MapContainer
+          center={center}
+          zoom={zoom}
+          boxZoom={false}
+          dragging={false}
+          doubleClickZoom={false}
+          zoomControl={false}
+          scrollWheelZoom={false}
+          touchZoom={false}
+          trackResize={false}
+          zoomSnap={0.25}
+          style={styles}
+        >
+          <GeoJSON
+            data={boundary}
+            style={geoJSONStyles}
+            onEachFeature={onEachFeature}
+          />
+        </MapContainer>
+      </Box>
     </Box>
   );
 }

--- a/apps/climatemappedafrica/src/components/Hero/Map.js
+++ b/apps/climatemappedafrica/src/components/Hero/Map.js
@@ -68,8 +68,8 @@ function Map({
       <Box
         sx={{
           position: "relative",
-          height: { sm: "350px", lg: "471px" },
-          width: { xs: "100%", sm: "300px", lg: "500px" },
+          height: "471px",
+          width: { xs: "100%", md: "300px", lg: "500px" },
           marginTop: { sm: "55px", lg: "42px" },
           "& .leaflet-container": {
             background: "transparent",

--- a/apps/climatemappedafrica/src/components/Hero/Map.js
+++ b/apps/climatemappedafrica/src/components/Hero/Map.js
@@ -17,7 +17,6 @@ function Map({
   geoJSONStyles = {
     color: "#2A2A2C",
     weight: 1,
-    opacity: 1,
     dashArray: "2",
   },
   onLayerMouseOver,
@@ -40,10 +39,7 @@ function Map({
     });
 
     if (regionCodes.includes(feature.properties.code?.toLowerCase())) {
-      layer.setStyle({
-        weight: 1.5,
-        dashArray: 0,
-      });
+      layer.setStyle(geoJSONStyles);
       layer.on("mouseover", () => {
         onLayerMouseOver(feature.properties.name.toLowerCase());
         if (explorePageSlug) {
@@ -55,7 +51,7 @@ function Map({
       });
       layer.on("mouseout", () => {
         onLayerMouseOver(null);
-        layer.setStyle({ ...choroplethColor, fillOpacity: 1 });
+        layer.setStyle({ ...choroplethColor, fillOpacity: 1, weight: 1 });
       });
       layer.on("click", () => {
         if (explorePageSlug) {
@@ -68,7 +64,7 @@ function Map({
   };
 
   return (
-    <Box display="flex" justifyContent="center">
+    <Box display="flex" justifyContent={{ xs: "center", md: "flex-end" }}>
       <Box
         sx={{
           position: "relative",

--- a/apps/climatemappedafrica/src/components/Hero/Map.js
+++ b/apps/climatemappedafrica/src/components/Hero/Map.js
@@ -48,8 +48,8 @@ function Map({
         onLayerMouseOver(feature.properties.name.toLowerCase());
         if (explorePageSlug) {
           layer.setStyle({
-            fillColor: theme.palette.primary.main,
-            fillOpacity: 0.5,
+            fillColor: choroplethColor?.fillColor,
+            fillOpacity: 0.4,
           });
         }
       });

--- a/apps/climatemappedafrica/src/lib/data/blockify/hero.js
+++ b/apps/climatemappedafrica/src/lib/data/blockify/hero.js
@@ -1,3 +1,5 @@
+import { generateChoropleth } from "@hurumap/next";
+
 import {
   fetchProfile,
   fetchProfileGeography,
@@ -12,6 +14,7 @@ export default async function hero(block, _api, _context, { hurumap }) {
   const {
     profilePage,
     rootGeography: { center, code, hasData: pinRootGeography },
+    profile: hurumapProfile,
   } = hurumap ?? { rootGeography: {} };
   const { geometries } = await fetchProfileGeography(code.toLowerCase());
   const { level } = geometries.boundary?.properties ?? {};
@@ -21,6 +24,12 @@ export default async function hero(block, _api, _context, { hurumap }) {
   };
   const childLevel = childLevelMaps[level];
   const { locations, preferredChildren } = await fetchProfile();
+  const chloropleth = hurumapProfile?.choropleth ?? null;
+  const { choropleth, legend } = generateChoropleth(
+    chloropleth,
+    locations,
+    "choropleth",
+  );
   const preferredChildrenPerLevel = preferredChildren[level];
   const { children } = geometries;
   const preferredLevel =
@@ -40,5 +49,7 @@ export default async function hero(block, _api, _context, { hurumap }) {
     pinRootGeography,
     properties: geometries.boundary?.properties,
     slug: "hero",
+    choropleth,
+    legend,
   };
 }

--- a/apps/climatemappedafrica/src/payload/blocks/Hero.js
+++ b/apps/climatemappedafrica/src/payload/blocks/Hero.js
@@ -52,6 +52,13 @@ const Hero = {
       label: "Comment",
       localized: true,
     },
+    {
+      name: "averageTemperature",
+      type: "text",
+      label: "Average Temperature",
+      defaultValue: "Average Temperature",
+      localized: true,
+    },
   ],
 };
 

--- a/packages/hurumap-next/src/index.js
+++ b/packages/hurumap-next/src/index.js
@@ -1,2 +1,3 @@
 export { default as Source } from "./Source";
 export { default as Map } from "./Map";
+export { generateChoropleth } from "./Map/utils";


### PR DESCRIPTION

## Description

As per the feedback given during the demo, it is a requirement that all maps on Climatemapped Africa be colour-coded to match the explore page. In the words of Eric _Climatemapped mirrors Pesa Yetu, the designs don't need to be exactly the same but Climatemapped should be an improvement of PesaYetu features._
This PR 
- Adds colour codes to the Hero Map component. 
- Ensures map is visible on mobile devices

Fixes #992 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


## Screenshots
![image](https://github.com/user-attachments/assets/fb2dd491-a274-47ac-a242-5651c81f6239)
![Screenshot 2024-11-07 at 12 20 39](https://github.com/user-attachments/assets/a6d24c12-8803-49dc-b3a2-9eea5c4afcef)
![Screenshot 2024-11-07 at 12 24 43](https://github.com/user-attachments/assets/4e7be7ca-a6c7-4b37-9d79-b6ec34a8ffeb)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
