### PR TITLE
Charter Africa: Update SMTP configuration

### DIFF
--- a/apps/charterafrica/package.json
+++ b/apps/charterafrica/package.json
@@ -68,7 +68,6 @@
     "monaco-editor": "catalog:",
     "next": "catalog:",
     "next-seo": "catalog:",
-    "nodemailer-sendgrid": "catalog:",
     "payload": "catalog:",
     "prop-types": "catalog:",
     "qs": "catalog:",

--- a/apps/charterafrica/server.ts
+++ b/apps/charterafrica/server.ts
@@ -4,7 +4,6 @@ import { spawn } from "child_process";
 import { loadEnvConfig } from "@next/env";
 import express from "express";
 import next from "next";
-import nodemailerSendgrid from "nodemailer-sendgrid";
 import payload from "payload";
 import { Payload } from "payload/dist/payload";
 
@@ -20,8 +19,17 @@ const dev = process.env.NODE_ENV !== "production";
 // https://github.com/vercel/next.js/discussions/33835#discussioncomment-2559392
 const hostname = process.env.NEXT_HOSTNAME || "localhost";
 const port = Number.parseInt(process.env.PORT || "3000", 10);
-const sendGridAPIKey = process.env.SENDGRID_API_KEY;
 
+const smtpAuthPass = process.env.SMTP_PASS || process.env.SENDGRID_API_KEY;
+const smtpFromName =
+  process.env.SMTP_FROM_NAME ||
+  process.env.SENDGRID_FROM_NAME ||
+  "Charter Africa CMS";
+const smtpFromAddress =
+  process.env.SMTP_FROM_ADDRESS ||
+  process.env.SENDGRID_FROM_EMAIL ||
+  "noreply@codeforafrica.org";
+const smtpPort = Number(process.env.SMTP_PORT || 587);
 // Make sure commands gracefully respect termination signals (e.g. from Docker)
 // Allow the graceful termination to be manually configurable
 if (!process.env.NEXT_MANUAL_SIG_HANDLE) {
@@ -35,15 +43,20 @@ const start = async (): Promise<void> => {
   let localPayload: Payload;
   try {
     localPayload = await payload.init({
-      ...(sendGridAPIKey
+      ...(smtpAuthPass
         ? {
             email: {
-              transportOptions: nodemailerSendgrid({
-                apiKey: sendGridAPIKey,
-              }),
-              fromName: process.env.SENDGRID_FROM_NAME || "Admin",
-              fromAddress:
-                process.env.SENDGRID_FROM_EMAIL || "admin@example.com",
+              transportOptions: {
+                auth: {
+                  user: process.env.SMTP_USER || "apikey",
+                  pass: smtpAuthPass,
+                },
+                host: process.env.SMTP_HOST || "smtp.sendgrid.net",
+                port: smtpPort,
+                secure: smtpPort === 465, // true for port 465, false (the default) for 587 and others
+              },
+              fromName: smtpFromName,
+              fromAddress: smtpFromAddress,
             },
           }
         : undefined),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -720,9 +720,6 @@ importers:
       next-seo:
         specifier: 'catalog:'
         version: 6.6.0(next@14.2.16(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      nodemailer-sendgrid:
-        specifier: 'catalog:'
-        version: 1.0.3
       payload:
         specifier: 'catalog:'
         version: 2.30.3(@swc/helpers@0.5.5)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.5))(webpack-cli@4.10.0))


### PR DESCRIPTION
## Description
The current email configuration is limited to using SendGrid for sending emails. To improve flexibility and enable the use of multiple SMTP providers such as AWS SES and Gmail. This change will allow us to easily switch between different email services if need (e.g switching Charterafrica to AWS SES).

This PR updates the SMTP configuration in the Charter Africa CMS server file to use the environment variables `SMTP_PASS`, `SMTP_FROM_NAME`, `SMTP_FROM_ADDRESS`, and `SMTP_PORT` for the SMTP authentication password, from name, from address, and port respectively. This ensures that the SMTP settings can be easily customized and managed.

Fixes #997

## Type of change


- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
