### PR TITLE
@/CivicSignalBlog: Fix failing build due to import of allowedAppSelect.tsx component in Payload users collection

### DIFF
--- a/apps/civicsignalblog/src/payload/components/allowedAppSelect/index.tsx
+++ b/apps/civicsignalblog/src/payload/components/allowedAppSelect/index.tsx
@@ -6,7 +6,7 @@ import applications from "#civicsignalblog/payload/lib/data/common/applications"
 
 function CustomSelectComponent({ path, label }) {
   const { user } = useAuth();
-  const { value, setValue } = useField<string>({ path });
+  const { value, setValue } = useField({ path });
   const [options, setOptions] = useState([]);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ function CustomSelectComponent({ path, label }) {
         path={path}
         name={path}
         options={options}
-        value={value}
+        value={String(value ?? "")}
         onChange={(e) => setValue(e.value)}
       />
     </div>


### PR DESCRIPTION

## Description
The custom  payload component `allowedAppSelect.tsx` is being used in `Users.js` collection. This causes build to fail by failing to parse the `string` type parameter in the `useField` hook call. 

This PR proposes a fix by: 
1. Removing the type parameter for the `useField` hook call and letting TypeScript infer the type.
2. Modifying the `value` prop by converting it to a string, ensuring it is never `null` or `undefined`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
