### PR TITLE
@/CivicSignalBlog - Fix: Add loginSucceeded Field to Payload CMS

### DIFF
--- a/apps/civicsignalblog/src/payload/globals/Forms/login/LoginTab.js
+++ b/apps/civicsignalblog/src/payload/globals/Forms/login/LoginTab.js
@@ -40,6 +40,12 @@ const LoginTab = {
       label: "Messages",
       fields: [
         {
+          name: "loginSucceeded",
+          type: "text",
+          defaultValue: "You are now logged in!",
+          required: true,
+        },
+        {
           name: "loginFailed",
           type: "text",
           defaultValue: "Your email or password was wrong.",


### PR DESCRIPTION
## Description

This PR introduces a fix for an issue identified during the integration with the CivicSignal web tools, where the `loginSucceeded` field was missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
