### PR TITLE
Fix Promise Tracker UI Breaking imports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -913,3 +913,79 @@ USER nextjs
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 CMD ["node", "apps/vpnmanager/server.js"]
+
+# ============================================================================
+# Promise Tracker
+# ============================================================================
+
+#
+# promisetracker-desp: image with all pesayetu dependencies
+# -----------------------------------------------------
+
+FROM base-deps AS promisetracker-deps
+
+COPY apps/promisetracker/package.json ./apps/promisetracker/package.json
+
+# Use virtual store: https://pnpm.io/cli/fetch#usage-scenario
+RUN pnpm --filter "./apps/promisetracker" install --offline --frozen-lockfile
+
+#
+# promisetracker-builder: image that uses deps to build shippable output
+# ------------------------------------------------------------------
+
+FROM base-builder AS promisetracker-builder
+
+ARG NEXT_TELEMETRY_DISABLED \
+  # Next.js / Payload (build time)
+  PORT \
+  # Next.js (runtime)
+  NEXT_PUBLIC_APP_NAME="Promise Tracker" \
+  NEXT_PUBLIC_APP_URL \
+  NEXT_PUBLIC_SENTRY_DSN \
+  NEXT_PUBLIC_SEO_DISABLED \
+  NEXT_PUBLIC_GOOGLE_ANALYTICS \
+  # Sentry (build time)
+  SENTRY_AUTH_TOKEN \
+  SENTRY_ENVIRONMENT \
+  SENTRY_ORG \
+  SENTRY_PROJECT
+
+# This is in app-builder instead of base-builder just incase app-deps adds deps
+COPY --from=promisetracker-deps /workspace/node_modules ./node_modules
+
+COPY --from=promisetracker-deps /workspace/apps/promisetracker/node_modules ./apps/promisetracker/node_modules
+
+COPY apps/promisetracker ./apps/promisetracker
+
+RUN --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+  pnpm --filter "./apps/promisetracker" build
+
+#
+# promisetracker-runner: final deployable image
+# -----------------------------------------
+
+FROM base-runner AS promisetracker-runner
+
+ARG API_SECRET_KEY
+RUN set -ex \
+  # Create nextjs cache dir w/ correct permissions
+  && mkdir -p ./apps/promisetracker/.next \
+  && chown nextjs:nodejs ./apps/promisetracker/.next
+
+# PNPM
+# symlink some dependencies
+COPY --from=promisetracker-builder --chown=nextjs:nodejs /workspace/node_modules ./node_modules
+
+# Next.js
+# Public assets
+COPY --from=promisetracker-builder --chown=nextjs:nodejs /workspace/apps/promisetracker/public ./apps/promisetracker/public
+
+# Automatically leverage output traces to reduce image size
+# https://nextjs.org/docs/advanced-features/output-file-tracing
+COPY --from=promisetracker-builder --chown=nextjs:nodejs /workspace/apps/promisetracker/.next/standalone ./apps/promisetracker
+COPY --from=promisetracker-builder --chown=nextjs:nodejs /workspace/apps/promisetracker/.next/static ./apps/promisetracker/.next/static
+USER nextjs
+
+# server.js is created by next build from the standalone output
+# https://nextjs.org/docs/pages/api-reference/next-config-js/output
+CMD ["node", "apps/promisetracker/server.js"]

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,6 @@ techlabblog:
 vpnmanager:
 	$(COMPOSE_BUILD_ENV) $(COMPOSE) --env-file apps/vpnmanager/.env.local up vpnmanager --build
 
+promisetracker:
+	$(COMPOSE_BUILD_ENV) $(COMPOSE) --env-file apps/promisetracker/.env.local up promisetracker --build
+

--- a/apps/promisetracker/instrumentation.js
+++ b/apps/promisetracker/instrumentation.js
@@ -1,0 +1,7 @@
+// Next.js requires this to be exported as register https://nextjs.org/docs/app/building-your-application/optimizing/instrumentation
+// eslint-disable-next-line import/prefer-default-export
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./sentry.server.config");
+  }
+}

--- a/apps/promisetracker/next.config.js
+++ b/apps/promisetracker/next.config.js
@@ -8,7 +8,7 @@ const outputFileTracingRoot = PROJECT_ROOT
   : undefined;
 
 const moduleExports = {
-  experimental: {
+  experimental: outputFileTracingRoot && {
     outputFileTracingRoot,
   },
   i18n: {

--- a/apps/promisetracker/next.config.js
+++ b/apps/promisetracker/next.config.js
@@ -55,18 +55,6 @@ const moduleExports = {
       },
     ];
   },
-
-  // Optional build-time configuration options
-  sentry: {
-    // See the 'Configure Source Maps' and 'Configure Legacy Browser Support'
-    // sections below for information on the following options:
-    //   - disableServerWebpackPlugin
-    //   - disableClientWebpackPlugin
-    //   - hideSourceMaps
-    //   - widenClientFileUpload
-    //   - transpileClientSDK
-    hideSourceMaps: false,
-  },
 };
 
 const sentryWebpackPluginOptions = {
@@ -79,6 +67,10 @@ const sentryWebpackPluginOptions = {
   silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.
+  hideSourceMaps: true,
+  org: process.env.SENTRY_ORG,
+  authToken: process.env.SENTRY_AUTH_TOKEN,
+  project: process.env.SENTRY_PROJECT,
 };
 
 // Make sure adding Sentry options is the last code to run before exporting, to

--- a/apps/promisetracker/package.json
+++ b/apps/promisetracker/package.json
@@ -31,6 +31,7 @@
     "@mui/material": "catalog:mui-styles",
     "@mui/styles": "catalog:mui-styles",
     "@mui/utils": "catalog:mui-styles",
+    "@mui/private-theming": "catalog:mui-styles",
     "@sentry/nextjs": "catalog:",
     "clsx": "catalog:",
     "date-fns": "catalog:",

--- a/apps/promisetracker/src/components/AboutPage/Partners.js
+++ b/apps/promisetracker/src/components/AboutPage/Partners.js
@@ -59,8 +59,4 @@ Partners.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-Partners.defaultProps = {
-  items: undefined,
-};
-
 export default Partners;

--- a/apps/promisetracker/src/components/AboutPage/PromiseCriteria.js
+++ b/apps/promisetracker/src/components/AboutPage/PromiseCriteria.js
@@ -36,9 +36,4 @@ PromiseCriteria.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-PromiseCriteria.defaultProps = {
-  items: undefined,
-  title: undefined,
-};
-
 export default PromiseCriteria;

--- a/apps/promisetracker/src/components/AboutPage/index.js
+++ b/apps/promisetracker/src/components/AboutPage/index.js
@@ -127,17 +127,4 @@ AboutPage.propTypes = {
   title: PropTypes.string,
 };
 
-AboutPage.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  content: undefined,
-  criteria: undefined,
-  description: undefined,
-  featuredImage: undefined,
-  footer: undefined,
-  navigation: undefined,
-  partners: undefined,
-  title: undefined,
-};
-
 export default AboutPage;

--- a/apps/promisetracker/src/components/ActNow/index.js
+++ b/apps/promisetracker/src/components/ActNow/index.js
@@ -161,10 +161,4 @@ ActNow.propTypes = {
   title: PropTypes.string,
 };
 
-ActNow.defaultProps = {
-  actionLabel: undefined,
-  description: undefined,
-  title: undefined,
-};
-
 export default ActNow;

--- a/apps/promisetracker/src/components/ActNowCard/BaseContent.js
+++ b/apps/promisetracker/src/components/ActNowCard/BaseContent.js
@@ -43,10 +43,4 @@ BaseCard.propTypes = {
   children: PropTypes.node,
 };
 
-BaseCard.defaultProps = {
-  onCloseCard: undefined,
-  description: undefined,
-  children: undefined,
-};
-
 export default BaseCard;

--- a/apps/promisetracker/src/components/ActNowCard/ConnectCard.js
+++ b/apps/promisetracker/src/components/ActNowCard/ConnectCard.js
@@ -7,7 +7,7 @@ import useStyles from "./useStyles";
 
 import CtAButton from "@/promisetracker/components/CtAButton";
 
-function ConnectCard({ closeCard, promiseActNow }) {
+function ConnectCard({ closeCard, promiseActNow = { connect: {} } }) {
   const {
     connect: {
       connect_title: connectTitle,
@@ -45,16 +45,6 @@ ConnectCard.propTypes = {
       connectTitle: PropTypes.string,
       connectDescription: PropTypes.string,
       connectButton: PropTypes.string,
-    },
-  }),
-};
-
-ConnectCard.defaultProps = {
-  promiseActNow: PropTypes.shape({
-    connect: {
-      connectTitle: null,
-      connectDescription: null,
-      connectButton: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/ActNowCard/FollowCard.js
+++ b/apps/promisetracker/src/components/ActNowCard/FollowCard.js
@@ -7,7 +7,7 @@ import useStyles from "./useStyles";
 
 import CtAButton from "@/promisetracker/components/CtAButton";
 
-function FollowCard({ closeCard, promiseActNow }) {
+function FollowCard({ closeCard, promiseActNow = { follow: {} } }) {
   const classes = useStyles();
 
   const {
@@ -54,16 +54,6 @@ FollowCard.propTypes = {
       followTitle: PropTypes.string,
       followDescription: PropTypes.string,
       followButton: PropTypes.string,
-    },
-  }),
-};
-
-FollowCard.defaultProps = {
-  promiseActNow: PropTypes.shape({
-    follow: {
-      followTitle: null,
-      followDescription: null,
-      followButton: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/ActNowCard/PetitionCard.js
+++ b/apps/promisetracker/src/components/ActNowCard/PetitionCard.js
@@ -2,7 +2,7 @@ import { Grid, Snackbar } from "@mui/material";
 import Alert from "@mui/material/Alert";
 import Router from "next/router";
 import { useSession } from "next-auth/react";
-import PropTypes, { string } from "prop-types";
+import PropTypes from "prop-types";
 import React, { useState } from "react";
 
 import BaseContent from "./BaseContent";
@@ -11,7 +11,11 @@ import useStyles from "./useStyles";
 import CtAButton from "@/promisetracker/components/CtAButton";
 import FormDialog from "@/promisetracker/components/FormDialog";
 
-function PetitionCard({ closeCard, promiseActNow, ...props }) {
+function PetitionCard({
+  closeCard,
+  promiseActNow = { petition: { petitionTitle: "", petitionDescription: "" } },
+  ...props
+}) {
   const {
     petition: {
       petition_title: petitionTitle,
@@ -100,18 +104,6 @@ PetitionCard.propTypes = {
     petition: {
       petitionTitle: PropTypes.string,
       petitionDescription: PropTypes.string,
-    },
-  }),
-};
-
-PetitionCard.defaultProps = {
-  petitionJoin: null,
-  petitionStart: null,
-  petitionTitle: string,
-  promiseActNow: PropTypes.shape({
-    petition: {
-      petitionTitle: null,
-      petitionDescription: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/ActNowCard/ShareCard.js
+++ b/apps/promisetracker/src/components/ActNowCard/ShareCard.js
@@ -10,7 +10,7 @@ import React from "react";
 import BaseContent from "./BaseContent";
 import useStyles from "./useStyles";
 
-function ShareCard({ closeCard, promiseActNow }) {
+function ShareCard({ closeCard, promiseActNow = { share: {} } }) {
   const classes = useStyles();
 
   const {
@@ -54,15 +54,6 @@ ShareCard.propTypes = {
     share: {
       shareTitle: PropTypes.string,
       shareDescription: PropTypes.string,
-    },
-  }),
-};
-
-ShareCard.defaultProps = {
-  promiseActNow: PropTypes.shape({
-    share: {
-      shareTitle: null,
-      shareDescription: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/ActNowCard/index.js
+++ b/apps/promisetracker/src/components/ActNowCard/index.js
@@ -17,7 +17,10 @@ import useStyles from "./useStyles";
 
 import UpdateFormDialog from "@/promisetracker/components/FormDialog/UpdateDialog";
 
-function ActNowButtonCard({ promise_act_now: promiseActNow, ...props }) {
+function ActNowButtonCard({
+  promise_act_now: promiseActNow = { act_now: {} },
+  ...props
+}) {
   const {
     act_now: {
       act_now_title: actNowTitle,
@@ -158,19 +161,6 @@ ActNowButtonCard.propTypes = {
       follow_label: PropTypes.string,
       update_label: PropTypes.string,
       share_label: PropTypes.string,
-    },
-  }),
-};
-
-ActNowButtonCard.defaultProps = {
-  promise_act_now: PropTypes.shape({
-    act_now: {
-      act_now_title: null,
-      connect_label: null,
-      petition_label: null,
-      follow_label: null,
-      update_label: null,
-      share_label: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/ActNowPage/LoggedIn.js
+++ b/apps/promisetracker/src/components/ActNowPage/LoggedIn.js
@@ -104,12 +104,4 @@ ActNowLoggedInPage.propTypes = {
   title: PropTypes.string,
 };
 
-ActNowLoggedInPage.defaultProps = {
-  footer: undefined,
-  navigation: undefined,
-  ownedPetitions: undefined,
-  signedPetitions: undefined,
-  title: undefined,
-};
-
 export default ActNowLoggedInPage;

--- a/apps/promisetracker/src/components/ActNowPage/index.js
+++ b/apps/promisetracker/src/components/ActNowPage/index.js
@@ -232,13 +232,4 @@ ActNow.propTypes = {
   title: PropTypes.string,
 };
 
-ActNow.defaultProps = {
-  actNow: null,
-  description: null,
-  footer: null,
-  navigation: null,
-  petitions: null,
-  title: null,
-};
-
 export default ActNow;

--- a/apps/promisetracker/src/components/ActNowSummary/index.js
+++ b/apps/promisetracker/src/components/ActNowSummary/index.js
@@ -62,9 +62,4 @@ ActNowSummary.propTypes = {
   }),
 };
 
-ActNowSummary.defaultProps = {
-  summary: undefined,
-  titles: undefined,
-};
-
 export default ActNowSummary;

--- a/apps/promisetracker/src/components/ActionDialog/index.js
+++ b/apps/promisetracker/src/components/ActionDialog/index.js
@@ -89,13 +89,4 @@ ActionDialog.propTypes = {
   title: PropTypes.string,
 };
 
-ActionDialog.defaultProps = {
-  children: undefined,
-  description: undefined,
-  name: undefined,
-  onClose: undefined,
-  open: undefined,
-  title: undefined,
-};
-
 export default ActionDialog;

--- a/apps/promisetracker/src/components/Article/PublicationInfo.js
+++ b/apps/promisetracker/src/components/Article/PublicationInfo.js
@@ -55,11 +55,4 @@ PublicationInfo.propTypes = {
   readTime: PropTypes.string,
 };
 
-PublicationInfo.defaultProps = {
-  classes: undefined,
-  author: undefined,
-  date: undefined,
-  readTime: undefined,
-};
-
 export default PublicationInfo;

--- a/apps/promisetracker/src/components/Article/Share.js
+++ b/apps/promisetracker/src/components/Article/Share.js
@@ -4,13 +4,6 @@ import Image from "next/image";
 import PropTypes from "prop-types";
 import React from "react";
 
-import download from "@/promisetracker/assets/share-download.svg?url";
-import embed from "@/promisetracker/assets/share-embed.svg?url";
-import facebook from "@/promisetracker/assets/share-facebook.svg?url";
-import instagram from "@/promisetracker/assets/share-instagram.svg?url";
-import sharelink from "@/promisetracker/assets/share-link.svg?url";
-import twitter from "@/promisetracker/assets/share-twitter.svg?url";
-
 const useStyles = makeStyles(({ palette }) => ({
   root: {
     alignItems: "center",
@@ -32,7 +25,7 @@ const useStyles = makeStyles(({ palette }) => ({
     },
   },
 }));
-function Share({ platforms, ...props }) {
+function Share({ platforms = [], ...props }) {
   const classes = useStyles(props);
   return (
     <div className={classes.root}>
@@ -59,48 +52,6 @@ Share.propTypes = {
     root: PropTypes.string,
   }),
   platforms: PropTypes.arrayOf(PropTypes.shape({})),
-};
-
-Share.defaultProps = {
-  classes: undefined,
-  platforms: [
-    {
-      image: {
-        url: sharelink,
-        alt: "",
-      },
-    },
-    {
-      image: {
-        url: embed,
-        alt: "",
-      },
-    },
-    {
-      image: {
-        url: download,
-        alt: "",
-      },
-    },
-    {
-      image: {
-        url: instagram,
-        alt: "",
-      },
-    },
-    {
-      image: {
-        url: twitter,
-        alt: "",
-      },
-    },
-    {
-      image: {
-        url: facebook,
-        alt: "",
-      },
-    },
-  ],
 };
 
 export default Share;

--- a/apps/promisetracker/src/components/Article/index.js
+++ b/apps/promisetracker/src/components/Article/index.js
@@ -13,12 +13,40 @@ import facebook from "@/promisetracker/assets/share-facebook.svg?url";
 import instagram from "@/promisetracker/assets/share-instagram.svg?url";
 import twitter from "@/promisetracker/assets/share-twitter.svg?url";
 
+const defaultProps = {
+  breadcrumb: "Article",
+  shareLabel: "Share:",
+  socialMedia: [
+    {
+      url: "https://github.com/codeforafrica",
+      image: {
+        url: instagram,
+        alt: "",
+      },
+    },
+
+    {
+      url: "https://twitter.com/Code4Africa?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5EShare",
+      image: {
+        url: twitter,
+        alt: "",
+      },
+    },
+    {
+      url: "https://www.facebook.com/CodeForAfrica/",
+      image: {
+        url: facebook,
+        alt: "",
+      },
+    },
+  ],
+};
 function Article({
   article,
-  breadcrumb,
-  socialMedia,
+  breadcrumb = defaultProps.breadcrumb,
+  socialMedia = defaultProps.socialMedia,
   classes: classesProp,
-  shareLabel,
+  shareLabel = defaultProps.shareLabel,
 }) {
   const classes = useStyles({ image: article.image, classes: classesProp });
   return (
@@ -111,36 +139,6 @@ Article.propTypes = {
   }),
   shareLabel: PropTypes.string,
   socialMedia: PropTypes.arrayOf(PropTypes.shape({})),
-};
-
-Article.defaultProps = {
-  breadcrumb: "Article",
-  classes: undefined,
-  shareLabel: "Share:",
-  socialMedia: [
-    {
-      url: "https://github.com/codeforafrica",
-      image: {
-        url: instagram,
-        alt: "",
-      },
-    },
-
-    {
-      url: "https://twitter.com/Code4Africa?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5EShare",
-      image: {
-        url: twitter,
-        alt: "",
-      },
-    },
-    {
-      url: "https://www.facebook.com/CodeForAfrica/",
-      image: {
-        url: facebook,
-        alt: "",
-      },
-    },
-  ],
 };
 
 export default Article;

--- a/apps/promisetracker/src/components/ArticleCard/index.js
+++ b/apps/promisetracker/src/components/ArticleCard/index.js
@@ -48,10 +48,4 @@ ArticleCard.propTypes = {
   href: PropTypes.string,
 };
 
-ArticleCard.defaultProps = {
-  children: undefined,
-  href: undefined,
-  classes: undefined,
-};
-
 export default ArticleCard;

--- a/apps/promisetracker/src/components/ContentPage/Section.js
+++ b/apps/promisetracker/src/components/ContentPage/Section.js
@@ -64,12 +64,4 @@ ContentSection.propTypes = {
   titleProps: PropTypes.shape({}),
 };
 
-ContentSection.defaultProps = {
-  aside: undefined,
-  asideProps: undefined,
-  contentProps: undefined,
-  title: undefined,
-  titleProps: undefined,
-};
-
 export default ContentSection;

--- a/apps/promisetracker/src/components/ContentPage/index.js
+++ b/apps/promisetracker/src/components/ContentPage/index.js
@@ -23,7 +23,7 @@ function ContentPage({
   contentProps,
   footer,
   navigation,
-  showTitle,
+  showTitle = true,
   slug,
   title,
   ...props
@@ -75,19 +75,6 @@ ContentPage.propTypes = {
   showTitle: PropTypes.bool,
   slug: PropTypes.string,
   title: PropTypes.string,
-};
-
-ContentPage.defaultProps = {
-  aside: undefined,
-  asideProps: undefined,
-  children: undefined,
-  classes: undefined,
-  contentProps: undefined,
-  footer: undefined,
-  navigation: undefined,
-  showTitle: true,
-  slug: undefined,
-  title: undefined,
 };
 
 export default ContentPage;

--- a/apps/promisetracker/src/components/CtAButton/index.js
+++ b/apps/promisetracker/src/components/CtAButton/index.js
@@ -21,8 +21,4 @@ CtAButton.propTypes = {
   }),
 };
 
-CtAButton.defaultProps = {
-  classes: undefined,
-};
-
 export default CtAButton;

--- a/apps/promisetracker/src/components/DataSource/index.js
+++ b/apps/promisetracker/src/components/DataSource/index.js
@@ -67,10 +67,4 @@ DataSource.propTypes = {
   }),
 };
 
-DataSource.defaultProps = {
-  classes: undefined,
-  label: undefined,
-  promise: undefined,
-};
-
 export default DataSource;

--- a/apps/promisetracker/src/components/Dataset/index.js
+++ b/apps/promisetracker/src/components/Dataset/index.js
@@ -187,8 +187,4 @@ Dataset.propTypes = {
     total_res_downloads: PropTypes.number,
   }),
 };
-
-Dataset.defaultProps = {
-  dataset: undefined,
-};
 export default Dataset;

--- a/apps/promisetracker/src/components/ErrorPage/index.js
+++ b/apps/promisetracker/src/components/ErrorPage/index.js
@@ -80,13 +80,4 @@ ErrorPage.propTypes = {
   title: PropTypes.string,
 };
 
-ErrorPage.defaultProps = {
-  articles: undefined,
-  description: undefined,
-  featuredImage: undefined,
-  footer: undefined,
-  navigation: undefined,
-  title: undefined,
-};
-
 export default ErrorPage;

--- a/apps/promisetracker/src/components/FAQ/Accordion.js
+++ b/apps/promisetracker/src/components/FAQ/Accordion.js
@@ -12,7 +12,12 @@ import useStyles from "./useStyles";
 import MinusIcon from "@/promisetracker/icons/Minus";
 import PlusIcon from "@/promisetracker/icons/Plus";
 
-function AccordionPanel({ expanded: expandedProp, summary, title, ...props }) {
+function AccordionPanel({
+  expanded: expandedProp = false,
+  summary,
+  title,
+  ...props
+}) {
   const classes = useStyles(props);
   const [expanded, setExpanded] = useState(expandedProp);
   const handleChange = () => {
@@ -46,10 +51,6 @@ AccordionPanel.propTypes = {
   expanded: PropTypes.bool,
   summary: PropTypes.string.isRequired,
   title: PropTypes.string.isRequired,
-};
-
-AccordionPanel.defaultProps = {
-  expanded: false,
 };
 
 export default AccordionPanel;

--- a/apps/promisetracker/src/components/FAQ/index.js
+++ b/apps/promisetracker/src/components/FAQ/index.js
@@ -25,8 +25,4 @@ FAQ.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-FAQ.defaultProps = {
-  items: undefined,
-};
-
 export default FAQ;

--- a/apps/promisetracker/src/components/FactCheckCard/index.js
+++ b/apps/promisetracker/src/components/FactCheckCard/index.js
@@ -47,10 +47,4 @@ FactCheckCard.propTypes = {
     titleContainer: PropTypes.string,
   }),
 };
-
-FactCheckCard.defaultProps = {
-  children: undefined,
-  classes: undefined,
-};
-
 export default FactCheckCard;

--- a/apps/promisetracker/src/components/Footer/Copyright.js
+++ b/apps/promisetracker/src/components/Footer/Copyright.js
@@ -12,7 +12,11 @@ const useStyles = makeStyles(({ typography }) => ({
   image: {},
 }));
 
-function Copyright({ children, typographyProps, ...props }) {
+function Copyright({
+  children,
+  typographyProps = { variant: "button" },
+  ...props
+}) {
   const classes = useStyles(props);
 
   return (
@@ -38,10 +42,4 @@ Copyright.propTypes = {
   typographyProps: PropTypes.shape({}),
 };
 
-Copyright.defaultProps = {
-  children: undefined,
-  typographyProps: {
-    variant: "button",
-  },
-};
 export default Copyright;

--- a/apps/promisetracker/src/components/Footer/index.js
+++ b/apps/promisetracker/src/components/Footer/index.js
@@ -226,13 +226,5 @@ MainFooter.propTypes = {
   quickLinks: PropTypes.arrayOf(PropTypes.shape({})),
   socialMedia: PropTypes.arrayOf(PropTypes.shape({})),
 };
-MainFooter.defaultProps = {
-  about: undefined,
-  copyright: undefined,
-  legalLinks: undefined,
-  organizationLogo: undefined,
-  quickLinks: undefined,
-  socialMedia: undefined,
-};
 
 export default MainFooter;

--- a/apps/promisetracker/src/components/Form/Input.js
+++ b/apps/promisetracker/src/components/Form/Input.js
@@ -6,7 +6,7 @@ import React from "react";
 
 import useStyles from "./useStyles";
 
-function Input({ className, type, ...props }) {
+function Input({ className, type = "text", ...props }) {
   const classes = useStyles(props);
 
   return (
@@ -22,11 +22,6 @@ function Input({ className, type, ...props }) {
 Input.propTypes = {
   className: PropTypes.string,
   type: PropTypes.oneOf(["email", "password", "tel", "text", "url"]),
-};
-
-Input.defaultProps = {
-  className: undefined,
-  type: "text",
 };
 
 export default Input;

--- a/apps/promisetracker/src/components/Form/Label.js
+++ b/apps/promisetracker/src/components/Form/Label.js
@@ -5,7 +5,7 @@ import React from "react";
 
 import useStyles from "./useStyles";
 
-function Label({ className, shrink, ...props }) {
+function Label({ className, shrink = false, ...props }) {
   const classes = useStyles(props);
 
   return (
@@ -22,11 +22,6 @@ function Label({ className, shrink, ...props }) {
 Label.propTypes = {
   className: PropTypes.string,
   shrink: PropTypes.bool,
-};
-
-Label.defaultProps = {
-  className: undefined,
-  shrink: false,
 };
 
 export default Label;

--- a/apps/promisetracker/src/components/FormDialog/Form.js
+++ b/apps/promisetracker/src/components/FormDialog/Form.js
@@ -291,28 +291,4 @@ Form.propTypes = {
   }),
 };
 
-Form.defaultProps = {
-  mandatoryText: null,
-  onChange: null,
-  onSubmit: null,
-  petitionLabel: null,
-  petitionHelper: null,
-  categoryLabel: null,
-  categoryHelper: null,
-  recipientLabel: null,
-  recipientDescription: null,
-  recipientNameLabel: null,
-  recipientEmailLabel: null,
-  recipientSocialLabel: null,
-  issueLabel: null,
-  issueHelper: null,
-  imageLabel: null,
-  imageHelper: null,
-  uploadInstruction: null,
-  uploadText: null,
-  signatureLabel: null,
-  signatureHelper: null,
-  values: null,
-};
-
 export default Form;

--- a/apps/promisetracker/src/components/FormDialog/FormTextField.js
+++ b/apps/promisetracker/src/components/FormDialog/FormTextField.js
@@ -61,12 +61,4 @@ FormTextField.propTypes = {
   type: PropTypes.string,
 };
 
-FormTextField.defaultProps = {
-  labelText: null,
-  helperDescription: null,
-  elemId: null,
-  required: null,
-  type: null,
-};
-
 export default FormTextField;

--- a/apps/promisetracker/src/components/FormDialog/UpdateDialog.js
+++ b/apps/promisetracker/src/components/FormDialog/UpdateDialog.js
@@ -19,7 +19,9 @@ import CtAButton from "@/promisetracker/components/CtAButton";
 function FormDialog({
   open,
   handleFormClose,
-  promise_act_now: promiseActNow,
+  promise_act_now: promiseActNow = {
+    update: {},
+  },
   ...props
 }) {
   const classes = useStyles(props);
@@ -83,19 +85,6 @@ FormDialog.propTypes = {
     update: {
       updateTitle: PropTypes.string,
       updateDescription: PropTypes.string,
-    },
-  }),
-};
-
-FormDialog.defaultProps = {
-  open: null,
-  handleFormClose: null,
-  petitionDescription: null,
-  petitionTitle: null,
-  promise_act_now: PropTypes.shape({
-    update: {
-      updateTitle: null,
-      updateDescription: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/FormDialog/UpdateForm.js
+++ b/apps/promisetracker/src/components/FormDialog/UpdateForm.js
@@ -17,7 +17,7 @@ import useStyles from "./useStyles";
 
 import CtAButton from "@/promisetracker/components/CtAButton";
 
-function Form({ promise_act_now: promiseActNow, ...props }) {
+function Form({ promise_act_now: promiseActNow = { update: {} }, ...props }) {
   const classes = useStyles(props);
   const theme = useTheme();
 
@@ -208,27 +208,6 @@ Form.propTypes = {
       whenLabelDescription: PropTypes.string,
       whoLabel: PropTypes.string,
       whoLabelDescription: PropTypes.string,
-    },
-  }),
-};
-
-Form.defaultProps = {
-  mandatoryText: null,
-  promise_act_now: PropTypes.shape({
-    update: {
-      uploadInstruction: null,
-      uploadText: null,
-      contactLabel: null,
-      contactLabelDescription: null,
-      evidenceLabel: null,
-      evidenceLabelDescription: null,
-      imageUploadDescription: null,
-      whatLabel: null,
-      whatLabelDescription: null,
-      whenLabel: null,
-      whenLabelDescription: null,
-      whoLabel: null,
-      whoLabelDescription: null,
     },
   }),
 };

--- a/apps/promisetracker/src/components/FormDialog/index.js
+++ b/apps/promisetracker/src/components/FormDialog/index.js
@@ -126,13 +126,4 @@ FormDialog.propTypes = {
   }),
 };
 
-FormDialog.defaultProps = {
-  open: null,
-  handleFormClose: null,
-  petitionSuccess: null,
-  petitionDescription: null,
-  petitionTitle: null,
-  session: null,
-};
-
 export default FormDialog;

--- a/apps/promisetracker/src/components/H1/index.js
+++ b/apps/promisetracker/src/components/H1/index.js
@@ -43,8 +43,4 @@ H1.propTypes = {
   className: PropTypes.string,
 };
 
-H1.defaultProps = {
-  className: undefined,
-};
-
 export default H1;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/DesktopChart/index.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/DesktopChart/index.js
@@ -111,8 +111,4 @@ DesktopChart.propTypes = {
   }),
 };
 
-DesktopChart.defaultProps = {
-  promisesByStatus: undefined,
-};
-
 export default DesktopChart;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/DesktopInfoStatusPopover.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/DesktopInfoStatusPopover.js
@@ -79,10 +79,6 @@ PaperTitle.propTypes = {
   onClose: PropTypes.func,
 };
 
-PaperTitle.defaultProps = {
-  onClose: undefined,
-};
-
 function PaperContent({ children, ...other }) {
   const classes = useStyles();
   return (
@@ -157,11 +153,6 @@ DesktopInfoStatusPopover.propTypes = {
     }),
   ),
   title: PropTypes.string,
-};
-
-DesktopInfoStatusPopover.defaultProps = {
-  items: undefined,
-  title: undefined,
 };
 
 export default DesktopInfoStatusPopover;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/MobileSvgChart.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/MobileSvgChart.js
@@ -29,7 +29,7 @@ function MobileSvgChart({
   stroke,
   strokeWidth,
   statusNumber,
-  statusPercentage,
+  statusPercentage = "0",
   status,
   ...props
 }) {

--- a/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/ProgressChart.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/ProgressChart.js
@@ -60,7 +60,7 @@ function ProgressChart({ progressStatuses, caption, ...props }) {
             stroke="1D1D1B"
             strokeWidth={1}
             statusNumber={progressStatus.count}
-            statusPercentage={progressStatus.percentage}
+            statusPercentage={progressStatus.percentage ?? "0"}
             status={progressStatus.title}
           />
         ))}

--- a/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/index.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/MobileChart/index.js
@@ -103,8 +103,4 @@ MobileChart.propTypes = {
   }),
 };
 
-MobileChart.defaultProps = {
-  promisesByStatus: undefined,
-};
-
 export default MobileChart;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/MobileInfoStatusPopover.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/MobileInfoStatusPopover.js
@@ -150,9 +150,4 @@ MobileInfoStatusPopover.propTypes = {
   title: PropTypes.string,
 };
 
-MobileInfoStatusPopover.defaultProps = {
-  items: undefined,
-  title: undefined,
-};
-
 export default MobileInfoStatusPopover;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
@@ -170,7 +170,6 @@ function ProfileDetails({
               disableFocusRipple
               aria-label="Share"
               size="small"
-              component="span"
               className={classes.iconButton}
             >
               <Share

--- a/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
@@ -170,6 +170,7 @@ function ProfileDetails({
               disableFocusRipple
               aria-label="Share"
               size="small"
+              component="span"
               className={classes.iconButton}
             >
               <Share

--- a/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/ProfileDetails.js
@@ -135,7 +135,6 @@ function ProfileDetails({
                 aria-label="Info"
                 size="small"
                 onClick={handleOnClick}
-                clicked={clicked}
                 className={classes.iconButton}
               >
                 {clicked ? (
@@ -170,6 +169,7 @@ function ProfileDetails({
               disableFocusRipple
               aria-label="Share"
               size="small"
+              component="div"
               className={classes.iconButton}
             >
               <Share
@@ -239,12 +239,6 @@ ProfileDetails.propTypes = {
       "Behind Schedule": PropTypes.arrayOf(PropTypes.shape({})),
     }),
   }),
-};
-
-ProfileDetails.defaultProps = {
-  criteria: undefined,
-  promisesByStatus: undefined,
-  tagline: undefined,
 };
 
 export default ProfileDetails;

--- a/apps/promisetracker/src/components/Hero/ProfileChart/RectChart/index.js
+++ b/apps/promisetracker/src/components/Hero/ProfileChart/RectChart/index.js
@@ -12,13 +12,13 @@ const useStyles = makeStyles(() => ({
 }));
 
 function ReactChart({
-  totalPromises,
-  completed,
-  inconclusive,
-  inProgress,
-  unstarted,
-  stalled,
-  behindSchedule,
+  totalPromises = 0,
+  completed = 0,
+  inconclusive = 0,
+  inProgress = 0,
+  unstarted = 0,
+  stalled = 0,
+  behindSchedule = 0,
   ...props
 }) {
   const classes = useStyles(props);
@@ -116,16 +116,6 @@ ReactChart.propTypes = {
   inProgress: PropTypes.number,
   totalPromises: PropTypes.number,
   unstarted: PropTypes.number,
-};
-
-ReactChart.defaultProps = {
-  behindSchedule: 0,
-  stalled: 0,
-  inconclusive: 0,
-  completed: 0,
-  inProgress: 0,
-  totalPromises: 0,
-  unstarted: 0,
 };
 
 export default ReactChart;

--- a/apps/promisetracker/src/components/Hero/index.js
+++ b/apps/promisetracker/src/components/Hero/index.js
@@ -96,11 +96,4 @@ Hero.propTypes = {
   promisesByStatus: PropTypes.shape({}),
 };
 
-Hero.defaultProps = {
-  criteria: undefined,
-  fullName: undefined,
-  promisesByStatus: undefined,
-  tagline: undefined,
-};
-
 export default Hero;

--- a/apps/promisetracker/src/components/IndividualRegistrationDialog/index.js
+++ b/apps/promisetracker/src/components/IndividualRegistrationDialog/index.js
@@ -17,7 +17,7 @@ function IndividualRegistrationDialog({
   name: nameProp,
   onClose,
   onSubmit,
-  open,
+  open = false,
   title,
   ...props
 }) {
@@ -75,14 +75,6 @@ IndividualRegistrationDialog.propTypes = {
   onSubmit: PropTypes.func,
   open: PropTypes.bool,
   title: PropTypes.string,
-};
-
-IndividualRegistrationDialog.defaultProps = {
-  name: null,
-  onClose: null,
-  onSubmit: null,
-  open: false,
-  title: null,
 };
 
 export default IndividualRegistrationDialog;

--- a/apps/promisetracker/src/components/IndividualRegistrationForm/Form.js
+++ b/apps/promisetracker/src/components/IndividualRegistrationForm/Form.js
@@ -275,13 +275,4 @@ Form.propTypes = {
   }),
 };
 
-Form.defaultProps = {
-  disabled: undefined,
-  errors: undefined,
-  fields: undefined,
-  name: undefined,
-  onSubmit: undefined,
-  status: undefined,
-};
-
 export default Form;

--- a/apps/promisetracker/src/components/IndividualRegistrationForm/index.js
+++ b/apps/promisetracker/src/components/IndividualRegistrationForm/index.js
@@ -8,7 +8,7 @@ import Form from "./Form";
 function IndividualRegistrationForm({
   defaultErrorMessage,
   fields,
-  onSubmit,
+  onSubmit = false,
   submitUrl,
 }) {
   const [status, setStatus] = useState({});
@@ -131,13 +131,6 @@ IndividualRegistrationForm.propTypes = {
   }),
   onSubmit: PropTypes.func,
   submitUrl: PropTypes.string,
-};
-
-IndividualRegistrationForm.defaultProps = {
-  defaultErrorMessage: undefined,
-  fields: undefined,
-  onSubmit: false,
-  submitUrl: undefined,
 };
 
 export default IndividualRegistrationForm;

--- a/apps/promisetracker/src/components/KeyPromises/KeyPromise.js
+++ b/apps/promisetracker/src/components/KeyPromises/KeyPromise.js
@@ -101,13 +101,4 @@ KeyPromise.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-KeyPromise.defaultProps = {
-  actionLabel: undefined,
-  classes: undefined,
-  description: undefined,
-  events: undefined,
-  statusHistory: undefined,
-  status: undefined,
-};
-
 export default KeyPromise;

--- a/apps/promisetracker/src/components/KeyPromises/index.js
+++ b/apps/promisetracker/src/components/KeyPromises/index.js
@@ -117,11 +117,4 @@ KeyPromises.propTypes = {
   titleProps: PropTypes.shape({}),
 };
 
-KeyPromises.defaultProps = {
-  actionLabel: undefined,
-  items: undefined,
-  title: undefined,
-  titleProps: undefined,
-};
-
 export default KeyPromises;

--- a/apps/promisetracker/src/components/LatestArticles/index.js
+++ b/apps/promisetracker/src/components/LatestArticles/index.js
@@ -60,11 +60,4 @@ LatestArticles.propTypes = {
   title: PropTypes.string,
 };
 
-LatestArticles.defaultProps = {
-  actionLabel: undefined,
-  classes: undefined,
-  items: undefined,
-  title: undefined,
-};
-
 export default LatestArticles;

--- a/apps/promisetracker/src/components/LatestPromises/index.js
+++ b/apps/promisetracker/src/components/LatestPromises/index.js
@@ -64,11 +64,4 @@ LatestPromises.propTypes = {
   title: PropTypes.string,
 };
 
-LatestPromises.defaultProps = {
-  actionLabel: undefined,
-  classes: undefined,
-  items: undefined,
-  title: undefined,
-};
-
 export default LatestPromises;

--- a/apps/promisetracker/src/components/LoginForm/Form.js
+++ b/apps/promisetracker/src/components/LoginForm/Form.js
@@ -101,13 +101,4 @@ Form.propTypes = {
   }),
 };
 
-Form.defaultProps = {
-  disabled: undefined,
-  errors: undefined,
-  fields: undefined,
-  name: undefined,
-  onSubmit: undefined,
-  status: undefined,
-};
-
 export default Form;

--- a/apps/promisetracker/src/components/LoginForm/index.js
+++ b/apps/promisetracker/src/components/LoginForm/index.js
@@ -5,7 +5,7 @@ import React, { useState } from "react";
 
 import Form from "./Form";
 
-function LoginForm({ onSubmit, classes }) {
+function LoginForm({ onSubmit = false, classes }) {
   const [status, setStatus] = useState({});
   const fields = {
     email: {
@@ -83,11 +83,6 @@ function LoginForm({ onSubmit, classes }) {
 LoginForm.propTypes = {
   classes: PropTypes.shape({}),
   onSubmit: PropTypes.func,
-};
-
-LoginForm.defaultProps = {
-  onSubmit: false,
-  classes: null,
 };
 
 export default LoginForm;

--- a/apps/promisetracker/src/components/LoginPage/index.js
+++ b/apps/promisetracker/src/components/LoginPage/index.js
@@ -73,8 +73,4 @@ Login.propTypes = {
   providers: PropTypes.shape({}),
 };
 
-Login.defaultProps = {
-  providers: undefined,
-};
-
 export default Login;

--- a/apps/promisetracker/src/components/Navigation/DesktopNavigation/MenuButton.js
+++ b/apps/promisetracker/src/components/Navigation/DesktopNavigation/MenuButton.js
@@ -48,11 +48,4 @@ MenuButton.propTypes = {
   active: PropTypes.bool,
 };
 
-MenuButton.defaultProps = {
-  size: undefined,
-  title: undefined,
-  href: undefined,
-  active: undefined,
-};
-
 export default MenuButton;

--- a/apps/promisetracker/src/components/Navigation/DesktopNavigation/NavigationButton.js
+++ b/apps/promisetracker/src/components/Navigation/DesktopNavigation/NavigationButton.js
@@ -53,11 +53,11 @@ const useStyles = makeStyles(({ spacing, palette, typography }) => ({
 }));
 
 function NavigationButton({
-  active,
+  active = false,
   anchorEl,
   button: buttonProp,
   children,
-  open: openProp,
+  open: openProp = false,
   onClose,
   popperProps,
   size,
@@ -128,15 +128,4 @@ NavigationButton.propTypes = {
   size: PropTypes.string,
 };
 
-NavigationButton.defaultProps = {
-  active: false,
-  anchorEl: undefined,
-  onClose: undefined,
-  open: false,
-  popperProps: undefined,
-  button: undefined,
-  title: undefined,
-  size: undefined,
-  children: undefined,
-};
 export default NavigationButton;

--- a/apps/promisetracker/src/components/Navigation/DesktopNavigation/PageNavigation.js
+++ b/apps/promisetracker/src/components/Navigation/DesktopNavigation/PageNavigation.js
@@ -98,9 +98,4 @@ PageNavigation.propTypes = {
   pathname: PropTypes.string,
 };
 
-PageNavigation.defaultProps = {
-  pathname: undefined,
-  asPath: undefined,
-};
-
 export default PageNavigation;

--- a/apps/promisetracker/src/components/Navigation/DesktopNavigation/index.js
+++ b/apps/promisetracker/src/components/Navigation/DesktopNavigation/index.js
@@ -207,8 +207,4 @@ DesktopNavigation.propTypes = {
   }),
 };
 
-DesktopNavigation.defaultProps = {
-  navigation: undefined,
-};
-
 export default DesktopNavigation;

--- a/apps/promisetracker/src/components/Navigation/MobileNavigation/NavigationList.js
+++ b/apps/promisetracker/src/components/Navigation/MobileNavigation/NavigationList.js
@@ -172,9 +172,4 @@ NavigationList.propTypes = {
   open: PropTypes.bool,
 };
 
-NavigationList.defaultProps = {
-  onNavigate: undefined,
-  open: undefined,
-};
-
 export default NavigationList;

--- a/apps/promisetracker/src/components/Navigation/MobileNavigation/index.js
+++ b/apps/promisetracker/src/components/Navigation/MobileNavigation/index.js
@@ -234,8 +234,4 @@ MobileNavigation.propTypes = {
   }),
 };
 
-MobileNavigation.defaultProps = {
-  navigation: undefined,
-};
-
 export default MobileNavigation;

--- a/apps/promisetracker/src/components/Navigation/index.js
+++ b/apps/promisetracker/src/components/Navigation/index.js
@@ -54,8 +54,4 @@ Navigation.propTypes = {
   navigation: PropTypes.shape({}),
 };
 
-Navigation.defaultProps = {
-  navigation: undefined,
-};
-
 export default Navigation;

--- a/apps/promisetracker/src/components/Newsletter/index.js
+++ b/apps/promisetracker/src/components/Newsletter/index.js
@@ -108,12 +108,7 @@ const useStyles = makeStyles(({ breakpoints, typography }) => ({
   },
 }));
 
-function Newsletter({
-  description: descriptionProp,
-  enterEmailPlaceholder,
-  title,
-  ...props
-}) {
+function Newsletter({ description: descriptionProp, title, ...props }) {
   const classes = useStyles(props);
   const description =
     (descriptionProp && descriptionProp.length > 0 && descriptionProp) ||
@@ -156,13 +151,6 @@ function Newsletter({
 Newsletter.propTypes = {
   description: PropTypes.string,
   title: PropTypes.string,
-  enterEmailPlaceholder: PropTypes.string,
-};
-
-Newsletter.defaultProps = {
-  description: undefined,
-  title: undefined,
-  enterEmailPlaceholder: "Please Enter your email",
 };
 
 export default Newsletter;

--- a/apps/promisetracker/src/components/Page/Base.js
+++ b/apps/promisetracker/src/components/Page/Base.js
@@ -68,10 +68,4 @@ BasePage.propTypes = {
   title: PropTypes.string,
 };
 
-BasePage.defaultProps = {
-  footer: undefined,
-  navigation: undefined,
-  title: undefined,
-};
-
 export default BasePage;

--- a/apps/promisetracker/src/components/Page/index.js
+++ b/apps/promisetracker/src/components/Page/index.js
@@ -25,8 +25,4 @@ Page.propTypes = {
   errorCode: PropTypes.number,
 };
 
-Page.defaultProps = {
-  errorCode: undefined,
-};
-
 export default Page;

--- a/apps/promisetracker/src/components/Partners/index.js
+++ b/apps/promisetracker/src/components/Partners/index.js
@@ -80,6 +80,7 @@ function Partners({ items, title, ...props }) {
   if (!items?.length) {
     return null;
   }
+
   return (
     <div className={classes.root}>
       <Section
@@ -95,7 +96,7 @@ function Partners({ items, title, ...props }) {
               className={classes.partners}
             >
               {items.slice(0, 6).map((partner) => (
-                <Grid item xs={12} lg="auto">
+                <Grid key={partner.name} item xs={12} lg="auto">
                   <Link href={partner.url} className={classes.partner}>
                     <Image
                       src={partner.image}
@@ -117,11 +118,6 @@ function Partners({ items, title, ...props }) {
 Partners.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({})),
   title: PropTypes.string,
-};
-
-Partners.defaultProps = {
-  items: undefined,
-  title: undefined,
 };
 
 export default Partners;

--- a/apps/promisetracker/src/components/Petition/index.js
+++ b/apps/promisetracker/src/components/Petition/index.js
@@ -205,8 +205,4 @@ Petition.propTypes = {
   }),
 };
 
-Petition.defaultProps = {
-  petitionPost: undefined,
-};
-
 export default Petition;

--- a/apps/promisetracker/src/components/PetitionCard/index.js
+++ b/apps/promisetracker/src/components/PetitionCard/index.js
@@ -167,16 +167,4 @@ PostCard.propTypes = {
   id: PropTypes.number,
 };
 
-PostCard.defaultProps = {
-  owner: undefined,
-  children: undefined,
-  classes: undefined,
-  description: undefined,
-  href: undefined,
-  as: undefined,
-  signatures: undefined,
-  status: undefined,
-  id: undefined,
-};
-
 export default PostCard;

--- a/apps/promisetracker/src/components/Petitions/index.js
+++ b/apps/promisetracker/src/components/Petitions/index.js
@@ -36,8 +36,4 @@ Index.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-Index.defaultProps = {
-  items: undefined,
-};
-
 export default Index;

--- a/apps/promisetracker/src/components/PickPromise/index.js
+++ b/apps/promisetracker/src/components/PickPromise/index.js
@@ -125,13 +125,4 @@ PickPromise.propTypes = {
   petitionJoin: PropTypes.string,
 };
 
-PickPromise.defaultProps = {
-  promises: null,
-  pickPromiseTitle: null,
-  pickPromiseDescription: null,
-  mandatoryText: null,
-  petitionStart: null,
-  petitionJoin: null,
-};
-
 export default PickPromise;

--- a/apps/promisetracker/src/components/PostCard/index.js
+++ b/apps/promisetracker/src/components/PostCard/index.js
@@ -109,13 +109,4 @@ PostCard.propTypes = {
   style: PropTypes.shape({}),
 };
 
-PostCard.defaultProps = {
-  children: undefined,
-  classes: undefined,
-  description: undefined,
-  href: undefined,
-  as: undefined,
-  style: undefined,
-};
-
 export default PostCard;

--- a/apps/promisetracker/src/components/PostCardGrid/index.js
+++ b/apps/promisetracker/src/components/PostCardGrid/index.js
@@ -53,12 +53,4 @@ PostCardGrid.propTypes = {
   title: PropTypes.string,
 };
 
-PostCardGrid.defaultProps = {
-  classes: undefined,
-  children: undefined,
-  component: undefined,
-  items: undefined,
-  title: undefined,
-};
-
 export default PostCardGrid;

--- a/apps/promisetracker/src/components/Promise/AuthorAtribution.js
+++ b/apps/promisetracker/src/components/Promise/AuthorAtribution.js
@@ -47,10 +47,10 @@ const useStyles = makeStyles(({ typography, palette, breakpoints }) => ({
   name: {},
 }));
 function AuthorAtribution({
-  title,
-  description,
-  image,
-  mobileTitle,
+  title = "Author Attribution",
+  description = "Intro text explaining why the user is seeing this chart here and where does it come from.",
+  image = "",
+  mobileTitle = "Data source embed",
   classes: classesProp,
 }) {
   const classes = useStyles({ image, classes: classesProp });
@@ -96,15 +96,6 @@ AuthorAtribution.propTypes = {
   description: PropTypes.string,
   image: PropTypes.string,
   mobileTitle: PropTypes.string,
-};
-
-AuthorAtribution.defaultProps = {
-  classes: undefined,
-  title: "Author Attribution",
-  mobileTitle: "Data source embed",
-  description:
-    "Intro text explaining why the user is seeing this chart here and where does it come from.",
-  image: "",
 };
 
 export default AuthorAtribution;

--- a/apps/promisetracker/src/components/Promise/Narative.js
+++ b/apps/promisetracker/src/components/Promise/Narative.js
@@ -137,10 +137,4 @@ NarativeUpdates.propTypes = {
   timelines: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-NarativeUpdates.defaultProps = {
-  description: undefined,
-  title: undefined,
-  timelines: undefined,
-};
-
 export default NarativeUpdates;

--- a/apps/promisetracker/src/components/Promise/RelatedFactChecks.js
+++ b/apps/promisetracker/src/components/Promise/RelatedFactChecks.js
@@ -53,9 +53,4 @@ RelatedFactChecks.propTypes = {
   factChecks: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-RelatedFactChecks.defaultProps = {
-  classes: undefined,
-  factChecks: undefined,
-};
-
 export default RelatedFactChecks;

--- a/apps/promisetracker/src/components/Promise/index.js
+++ b/apps/promisetracker/src/components/Promise/index.js
@@ -17,7 +17,7 @@ import Status from "@/promisetracker/components/PromiseStatus";
 
 function Promise({
   promise,
-  breadcrumb,
+  breadcrumb = "Promises",
   classes: classesProp,
   promiseStatusLabel,
   promiseRadarLabel,
@@ -152,19 +152,6 @@ Promise.propTypes = {
   narrativeUpdatesLabel: PropTypes.string,
   chartEmbedLabel: PropTypes.string,
   authorAttributionLabel: PropTypes.string,
-};
-
-Promise.defaultProps = {
-  breadcrumb: "Promises",
-  classes: undefined,
-  promiseStatusLabel: undefined,
-  promiseRadarLabel: undefined,
-  relatedFactChecksLabel: undefined,
-  dataSourceEmbedLabel: undefined,
-  narrativeUpdatesLabel: undefined,
-  chartEmbedLabel: undefined,
-  authorAttributionLabel: undefined,
-  status: undefined,
 };
 
 export default Promise;

--- a/apps/promisetracker/src/components/PromiseCard/index.js
+++ b/apps/promisetracker/src/components/PromiseCard/index.js
@@ -61,10 +61,4 @@ PromiseCard.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-PromiseCard.defaultProps = {
-  children: undefined,
-  classes: undefined,
-  href: undefined,
-};
-
 export default PromiseCard;

--- a/apps/promisetracker/src/components/PromiseChart/index.js
+++ b/apps/promisetracker/src/components/PromiseChart/index.js
@@ -37,10 +37,4 @@ PromiseChart.propTypes = {
   description: PropTypes.string,
 };
 
-PromiseChart.defaultProps = {
-  chartLinks: null,
-  title: PropTypes.title,
-  description: PropTypes.description,
-};
-
 export default PromiseChart;

--- a/apps/promisetracker/src/components/PromiseStatus/index.js
+++ b/apps/promisetracker/src/components/PromiseStatus/index.js
@@ -42,10 +42,4 @@ Status.propTypes = {
   title: PropTypes.string.isRequired,
 };
 
-Status.defaultProps = {
-  className: undefined,
-  color: undefined,
-  textColor: undefined,
-};
-
 export default Status;

--- a/apps/promisetracker/src/components/PromiseStatusList/index.js
+++ b/apps/promisetracker/src/components/PromiseStatusList/index.js
@@ -51,8 +51,4 @@ PromiseStatusList.propTypes = {
   ),
 };
 
-PromiseStatusList.defaultProps = {
-  items: undefined,
-};
-
 export default PromiseStatusList;

--- a/apps/promisetracker/src/components/PromiseTimeline/PromiseStatus.js
+++ b/apps/promisetracker/src/components/PromiseTimeline/PromiseStatus.js
@@ -42,11 +42,7 @@ function PromiseStatus({ children, color, date: dateProp, ...props }) {
 PromiseStatus.propTypes = {
   children: PropTypes.node,
   color: PropTypes.string.isRequired,
-  date: PropTypes.number,
+  date: PropTypes.string,
 };
 
-PromiseStatus.defaultProps = {
-  children: undefined,
-  date: undefined,
-};
 export default PromiseStatus;

--- a/apps/promisetracker/src/components/PromiseTimeline/TimelineEvent.js
+++ b/apps/promisetracker/src/components/PromiseTimeline/TimelineEvent.js
@@ -4,7 +4,15 @@ import React, { useState, useRef } from "react";
 
 import config from "@/promisetracker/config";
 
-function Event({ color, isOdd, radius, rx, textColor, title, year }) {
+function Event({
+  color = "#fff",
+  isOdd = false,
+  radius = "4",
+  rx = "0",
+  textColor = "#202020",
+  title,
+  year,
+}) {
   const interval = config.promiseInterval;
   const theme = useTheme();
   const xposition = `${
@@ -70,11 +78,4 @@ Event.propTypes = {
   year: PropTypes.number.isRequired,
 };
 
-Event.defaultProps = {
-  color: "#fff",
-  isOdd: false,
-  radius: "4",
-  rx: "0",
-  textColor: "#202020",
-};
 export default Event;

--- a/apps/promisetracker/src/components/PromiseTimeline/index.js
+++ b/apps/promisetracker/src/components/PromiseTimeline/index.js
@@ -15,7 +15,7 @@ const useStyles = makeStyles(() => ({
 }));
 
 function PromiseTimeline({
-  events,
+  events = [],
   status,
   statusHistory: statusHistoryProp,
   ...props
@@ -37,7 +37,7 @@ function PromiseTimeline({
         }}
       />
       {isDesktop &&
-        events?.map((event) => <PromiseEvent key={event.label} {...event} />)}
+        events?.map((event) => <PromiseEvent key={event.name} {...event} />)}
       {statusHistory?.map((currentStatus, idx) => (
         <PromiseStatus
           key={currentStatus.date}
@@ -66,11 +66,6 @@ PromiseTimeline.propTypes = {
   events: PropTypes.arrayOf(PropTypes.shape({})),
   status: PropTypes.shape({}),
   statusHistory: PropTypes.arrayOf(PropTypes.shape({})),
-};
-PromiseTimeline.defaultProps = {
-  events: [],
-  status: undefined,
-  statusHistory: undefined,
 };
 
 export default PromiseTimeline;

--- a/apps/promisetracker/src/components/Promises/Filter/FilterButton.js
+++ b/apps/promisetracker/src/components/Promises/Filter/FilterButton.js
@@ -32,11 +32,4 @@ FilterButton.propTypes = {
   onClick: PropTypes.func,
 };
 
-FilterButton.defaultProps = {
-  active: undefined,
-  name: undefined,
-  slug: undefined,
-  onClick: undefined,
-};
-
 export default FilterButton;

--- a/apps/promisetracker/src/components/Promises/Filter/index.js
+++ b/apps/promisetracker/src/components/Promises/Filter/index.js
@@ -59,12 +59,4 @@ Filter.propTypes = {
   variant: PropTypes.string,
 };
 
-Filter.defaultProps = {
-  classes: undefined,
-  items: undefined,
-  label: undefined,
-  onClick: undefined,
-  variant: undefined,
-};
-
 export default Filter;

--- a/apps/promisetracker/src/components/Promises/Sort.js
+++ b/apps/promisetracker/src/components/Promises/Sort.js
@@ -52,8 +52,4 @@ Sort.propTypes = {
   slug: PropTypes.string.isRequired,
 };
 
-Sort.defaultProps = {
-  onClick: undefined,
-};
-
 export default Sort;

--- a/apps/promisetracker/src/components/Promises/index.js
+++ b/apps/promisetracker/src/components/Promises/index.js
@@ -13,9 +13,9 @@ import { slugify } from "@/promisetracker/utils";
 function Promises({
   items: itemsProp,
   title,
-  withFilter,
+  withFilter = true,
   projectMeta,
-  promiseStatuses,
+  promiseStatuses = [],
   sortLabels,
   ...props
 }) {
@@ -205,16 +205,6 @@ Promises.propTypes = {
   }),
   title: PropTypes.string,
   withFilter: PropTypes.bool,
-};
-
-Promises.defaultProps = {
-  classes: undefined,
-  items: undefined,
-  projectMeta: undefined,
-  promiseStatuses: [],
-  sortLabels: undefined,
-  title: undefined,
-  withFilter: true,
 };
 
 export default Promises;

--- a/apps/promisetracker/src/components/RegistrationDialog/index.js
+++ b/apps/promisetracker/src/components/RegistrationDialog/index.js
@@ -77,12 +77,4 @@ RegistrationDialog.propTypes = {
   open: PropTypes.bool,
 };
 
-RegistrationDialog.defaultProps = {
-  individualRegistrationDialogProps: undefined,
-  name: null,
-  onClose: null,
-  onSubmit: null,
-  open: false,
-};
-
 export default RegistrationDialog;

--- a/apps/promisetracker/src/components/Search.js
+++ b/apps/promisetracker/src/components/Search.js
@@ -35,7 +35,13 @@ const useStyles = makeStyles(({ breakpoints, palette, typography }) => ({
   },
 }));
 
-function Search({ ariaLabel, onClick, onChange, placeholder, ...props }) {
+function Search({
+  ariaLabel = "",
+  onClick,
+  onChange,
+  placeholder = "SEARCH",
+  ...props
+}) {
   const classes = useStyles(props);
   const [term, setTerm] = useState();
   const handleChange = (e) => {
@@ -93,10 +99,4 @@ Search.propTypes = {
   onClick: PropTypes.func,
 };
 
-Search.defaultProps = {
-  ariaLabel: "",
-  onChange: undefined,
-  onClick: undefined,
-  placeholder: "SEARCH",
-};
 export default Search;

--- a/apps/promisetracker/src/components/Share/index.js
+++ b/apps/promisetracker/src/components/Share/index.js
@@ -141,12 +141,4 @@ Share.propTypes = {
   description: PropTypes.string,
 };
 
-Share.defaultProps = {
-  children: undefined,
-  classes: undefined,
-  link: undefined,
-  title: undefined,
-  description: undefined,
-};
-
 export default Share;

--- a/apps/promisetracker/src/components/SignPetition/index.js
+++ b/apps/promisetracker/src/components/SignPetition/index.js
@@ -105,9 +105,4 @@ SignPetition.propTypes = {
   session: PropTypes.shape({}),
 };
 
-SignPetition.defaultProps = {
-  signatures: undefined,
-  session: undefined,
-};
-
 export default SignPetition;

--- a/apps/promisetracker/src/components/SuggestPromise/index.js
+++ b/apps/promisetracker/src/components/SuggestPromise/index.js
@@ -27,6 +27,4 @@ SuggestPromise.propTypes = {
   label: PropTypes.string.isRequired,
 };
 
-SuggestPromise.defaultProps = {};
-
 export default SuggestPromise;

--- a/apps/promisetracker/src/components/Tabs/TabPanel.js
+++ b/apps/promisetracker/src/components/Tabs/TabPanel.js
@@ -30,11 +30,4 @@ TabPanel.propTypes = {
   selected: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 };
 
-TabPanel.defaultProps = {
-  children: undefined,
-  value: undefined,
-  name: undefined,
-  selected: undefined,
-};
-
 export default TabPanel;

--- a/apps/promisetracker/src/components/Tabs/index.js
+++ b/apps/promisetracker/src/components/Tabs/index.js
@@ -84,10 +84,4 @@ Tabs.propTypes = {
   ),
 };
 
-Tabs.defaultProps = {
-  activeTab: 0,
-  items: undefined,
-  name: undefined,
-};
-
 export default Tabs;

--- a/apps/promisetracker/src/lib/gsheets/index.js
+++ b/apps/promisetracker/src/lib/gsheets/index.js
@@ -1,3 +1,5 @@
+import { Readable } from "stream";
+
 import { camelCase, merge } from "lodash";
 import papa from "papaparse";
 
@@ -73,7 +75,8 @@ function gsheets(server) {
     const response = await fetch(
       `${SPREADSHEETS_URL}d/${spreadsheetId}/export?format=csv&gid=${sheetId}`,
     );
-    return papaPromise(response.body, options);
+    const nodeStream = Readable.from(response.body);
+    return papaPromise(nodeStream, options);
   }
 
   async function fetchSitesNavigationsSheet() {

--- a/apps/promisetracker/src/lib/wp/index.js
+++ b/apps/promisetracker/src/lib/wp/index.js
@@ -181,7 +181,7 @@ function wp(site) {
     });
     const resource = resources[0];
     if (isEmpty(resource)) {
-      return undefined;
+      return null;
     }
 
     /* eslint  no-underscore-dangle: off */
@@ -349,13 +349,15 @@ function wp(site) {
             pageWithPosts = page;
           }
           const posts =
-            pageWithPosts?.posts?.map((post) => ({
-              image: post.thumbnail_image,
-              description: post.content.replace(/(<([^>]+)>)/gi, ""),
-              date: formatDate(post.date),
-              slug: post.slug,
-              title: post.title,
-            })) || null;
+            pageWithPosts?.posts
+              ?.filter((post) => !!post)
+              ?.map((post) => ({
+                image: post.thumbnail_image,
+                description: post.content.replace(/(<([^>]+)>)/gi, ""),
+                date: formatDate(post.date),
+                slug: post.slug,
+                title: post.title,
+              })) || null;
           return posts;
         })();
       },

--- a/apps/promisetracker/src/pages/_app.page.js
+++ b/apps/promisetracker/src/pages/_app.page.js
@@ -1,7 +1,6 @@
 /* eslint-env browser */
 import { CssBaseline } from "@mui/material";
-import { StyledEngineProvider } from "@mui/material/styles";
-import { ThemeProvider } from "@mui/styles";
+import { StyledEngineProvider, ThemeProvider } from "@mui/material/styles";
 import { SessionProvider } from "next-auth/react";
 import { DefaultSeo } from "next-seo";
 import PropTypes from "prop-types";

--- a/apps/promisetracker/src/pages/_app.page.js
+++ b/apps/promisetracker/src/pages/_app.page.js
@@ -1,6 +1,7 @@
 /* eslint-env browser */
 import { CssBaseline } from "@mui/material";
-import { ThemeProvider, StyledEngineProvider } from "@mui/material/styles";
+import { StyledEngineProvider } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/styles";
 import { SessionProvider } from "next-auth/react";
 import { DefaultSeo } from "next-seo";
 import PropTypes from "prop-types";

--- a/apps/promisetracker/src/pages/_app.page.js
+++ b/apps/promisetracker/src/pages/_app.page.js
@@ -16,13 +16,6 @@ import "simplebar-react/dist/simplebar.min.css";
 
 export default function MyApp(props) {
   const { Component, pageProps } = props;
-  React.useEffect(() => {
-    // Remove the server-side injected CSS.
-    const jssStyles = document.querySelector("#jss-server-side");
-    if (jssStyles) {
-      jssStyles.parentElement.removeChild(jssStyles);
-    }
-  }, []);
 
   return (
     <>

--- a/apps/promisetracker/src/pages/analysis/articles/[slug].page.js
+++ b/apps/promisetracker/src/pages/analysis/articles/[slug].page.js
@@ -106,16 +106,6 @@ Index.propTypes = {
   title: PropTypes.string,
 };
 
-Index.defaultProps = {
-  article: undefined,
-  classes: undefined,
-  footer: undefined,
-  navigation: undefined,
-  relatedArticles: undefined,
-  subscribe: undefined,
-  title: undefined,
-};
-
 export async function getStaticPaths() {
   const fallback = true;
   const page = await wp().pages({ slug: "analysis-articles" }).first;

--- a/apps/promisetracker/src/pages/analysis/articles/index.page.js
+++ b/apps/promisetracker/src/pages/analysis/articles/index.page.js
@@ -98,16 +98,6 @@ Index.propTypes = {
   title: PropTypes.string,
 };
 
-Index.defaultProps = {
-  actNowEnabled: undefined,
-  actNow: undefined,
-  articles: undefined,
-  footer: undefined,
-  navigation: undefined,
-  subscribe: undefined,
-  title: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/analysis/fact-checks.page.js
+++ b/apps/promisetracker/src/pages/analysis/fact-checks.page.js
@@ -98,16 +98,6 @@ FactChecks.propTypes = {
   title: PropTypes.string,
 };
 
-FactChecks.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  factChecks: undefined,
-  footer: undefined,
-  navigation: undefined,
-  subscribe: undefined,
-  title: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/analysis/petitions/[slug].page.js
+++ b/apps/promisetracker/src/pages/analysis/petitions/[slug].page.js
@@ -88,17 +88,6 @@ Index.propTypes = {
   title: PropTypes.string,
 };
 
-Index.defaultProps = {
-  article: undefined,
-  classes: undefined,
-  footer: undefined,
-  navigation: undefined,
-  relatedArticles: undefined,
-  subscribe: undefined,
-  title: undefined,
-  petition: undefined,
-};
-
 export async function getStaticPaths() {
   const fallback = true;
   const petitions = await actnow().petitions().fetchAll();

--- a/apps/promisetracker/src/pages/analysis/petitions/index.page.js
+++ b/apps/promisetracker/src/pages/analysis/petitions/index.page.js
@@ -110,16 +110,6 @@ Index.propTypes = {
   title: PropTypes.string,
 };
 
-Index.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  footer: undefined,
-  navigation: undefined,
-  petitions: undefined,
-  subscribe: undefined,
-  title: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/analysis/resources.page.js
+++ b/apps/promisetracker/src/pages/analysis/resources.page.js
@@ -68,13 +68,6 @@ Resources.propTypes = {
   navigation: PropTypes.shape({}),
 };
 
-Resources.defaultProps = {
-  actNow: undefined,
-  description: undefined,
-  footer: undefined,
-  navigation: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/faq.page.js
+++ b/apps/promisetracker/src/pages/faq.page.js
@@ -85,9 +85,10 @@ export async function getStaticProps({ locale }) {
   const backend = backendFn();
   const site = await backend.sites().current;
   const page = await wp().pages({ slug: "faq", locale }).first;
-  const faqs = page.faqs
-    .reduce((arr, e) => arr.concat(e.questions_answers), [])
-    .map((faq) => ({ title: faq.question, summary: faq.answer }));
+  const faqs =
+    page?.faqs
+      ?.reduce((arr, e) => arr.concat(e.questions_answers), [])
+      ?.map((faq) => ({ title: faq.question, summary: faq.answer })) ?? [];
   const languageAlternates = _.languageAlternates("/faq");
 
   return {

--- a/apps/promisetracker/src/pages/faq.page.js
+++ b/apps/promisetracker/src/pages/faq.page.js
@@ -66,14 +66,6 @@ FaqPage.propTypes = {
   faqs: PropTypes.arrayOf(PropTypes.shape({})),
 };
 
-FaqPage.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  footer: undefined,
-  navigation: undefined,
-  faqs: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/index.page.js
+++ b/apps/promisetracker/src/pages/index.page.js
@@ -152,22 +152,6 @@ Index.propTypes = {
   subscribe: PropTypes.shape({}),
 };
 
-Index.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  articles: undefined,
-  criteria: undefined,
-  footer: undefined,
-  navigation: undefined,
-  partners: undefined,
-  promiseStatuses: undefined,
-  promises: undefined,
-  keyPromises: undefined,
-  promisesByStatus: undefined,
-  subscribe: undefined,
-  projectMeta: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   // Skip generating pages for unsupported locales

--- a/apps/promisetracker/src/pages/join.page.js
+++ b/apps/promisetracker/src/pages/join.page.js
@@ -78,14 +78,6 @@ Join.propTypes = {
   navigation: PropTypes.shape({}),
 };
 
-Join.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  description: undefined,
-  footer: undefined,
-  navigation: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/login.page.js
+++ b/apps/promisetracker/src/pages/login.page.js
@@ -60,10 +60,6 @@ Login.propTypes = {
   providers: PropTypes.shape({}),
 };
 
-Login.defaultProps = {
-  providers: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   // Skip generating pages for unsupported locales

--- a/apps/promisetracker/src/pages/promises/[...slug].page.js
+++ b/apps/promisetracker/src/pages/promises/[...slug].page.js
@@ -139,16 +139,6 @@ PromisePage.propTypes = {
   title: PropTypes.string,
 };
 
-PromisePage.defaultProps = {
-  classes: undefined,
-  footer: undefined,
-  labels: undefined,
-  navigation: undefined,
-  promise: undefined,
-  promiseStatuses: undefined,
-  title: undefined,
-};
-
 export async function getStaticPaths() {
   const fallback = false;
 

--- a/apps/promisetracker/src/pages/promises/index.page.js
+++ b/apps/promisetracker/src/pages/promises/index.page.js
@@ -93,19 +93,6 @@ PromisesPage.propTypes = {
   title: PropTypes.string,
 };
 
-PromisesPage.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  promises: undefined,
-  sortLabels: undefined,
-  promiseStatuses: undefined,
-  projectMeta: undefined,
-  footer: undefined,
-  navigation: undefined,
-  subscribe: undefined,
-  title: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/resources.page.js
+++ b/apps/promisetracker/src/pages/resources.page.js
@@ -78,14 +78,6 @@ Resources.propTypes = {
   navigation: PropTypes.shape({}),
 };
 
-Resources.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  description: undefined,
-  footer: undefined,
-  navigation: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/pages/subscribe.page.js
+++ b/apps/promisetracker/src/pages/subscribe.page.js
@@ -63,14 +63,6 @@ SubscribePage.propTypes = {
   subscribe: PropTypes.shape({}),
 };
 
-SubscribePage.defaultProps = {
-  actNow: undefined,
-  actNowEnabled: undefined,
-  footer: undefined,
-  navigation: undefined,
-  subscribe: undefined,
-};
-
 export async function getStaticProps({ locale }) {
   const _ = i18n();
   if (!_.locales.includes(locale)) {

--- a/apps/promisetracker/src/theme/index.js
+++ b/apps/promisetracker/src/theme/index.js
@@ -1,4 +1,4 @@
-import { createTheme } from "@commons-ui/core";
+import { createTheme } from "@mui/material/styles";
 import { deepmerge } from "@mui/utils";
 
 const FONT_FAMILY_HEADING = '"Amiri", "serif"';

--- a/apps/promisetracker/turbo.json
+++ b/apps/promisetracker/turbo.json
@@ -14,7 +14,10 @@
         "ACTNOW_API_KEY",
         "GOOGLE_ID",
         "GOOGLE_SECRET",
-        "NEXTAUTH_SECRET"
+        "NEXTAUTH_SECRET",
+        "SENTRY_AUTH_TOKEN",
+        "SENTRY_ORG",
+        "SENTRY_PROJECT"
       ]
     }
   }

--- a/apps/promisetracker/turbo.json
+++ b/apps/promisetracker/turbo.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "env": ["NEXT_RUNTIME"]
+    }
+  }
+}

--- a/apps/promisetracker/turbo.json
+++ b/apps/promisetracker/turbo.json
@@ -3,7 +3,19 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "env": ["NEXT_RUNTIME"]
+      "env": [
+        "NEXT_RUNTIME",
+        "PROJECT_ROOT",
+        "PROMISE_TRACKER_SENTRY_DSN",
+        "PUBLIC_PROMISE_TRACKER_SENTRY_DSN",
+        "SOURCE_LIB",
+        "APP_SLUG",
+        "ACTNOW_URL",
+        "ACTNOW_API_KEY",
+        "GOOGLE_ID",
+        "GOOGLE_SECRET",
+        "NEXTAUTH_SECRET"
+      ]
     }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -206,6 +206,22 @@ services:
       - ${VPN_MANAGER_PORT:-3000}:3000
     volumes:
       - ./db_data:/apps/vpnmanager/data
+
+  promisetracker:
+    build:
+      secrets:
+        - sentry_auth_token
+      context: .
+      target: promisetracker-runner
+      args:
+        - SENTRY_ORG
+        - SENTRY_PROJECT
+        - SENTRY_DSN
+        - API_SECRET_KEY
+    environment:
+      NODE_ENV: ${NODE_ENV:-production}
+    ports:
+      - ${PROMISE_TRACKER_PORT:-3000}:3000
 secrets:
   sentry_auth_token:
     environment: SENTRY_AUTH_TOKEN

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ catalogs:
     '@mui/material':
       specifier: ^5.16.6
       version: 5.16.7
+    '@mui/private-theming':
+      specifier: ^5.16.6
+      version: 5.16.6
     '@mui/styles':
       specifier: ^5.16.6
       version: 5.16.7
@@ -686,31 +689,31 @@ importers:
         version: 0.84.0(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@payloadcms/bundler-webpack':
         specifier: 'catalog:'
-        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(sass@1.69.4)
+        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(sass@1.69.4)
       '@payloadcms/db-mongodb':
         specifier: 'catalog:'
-        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))
+        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-cloud-storage':
         specifier: 'catalog:'
-        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))
+        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-nested-docs':
         specifier: 'catalog:'
-        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))
+        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-sentry':
         specifier: 'catalog:'
-        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react@18.3.1)
+        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/plugin-seo':
         specifier: 'catalog:'
-        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react@18.3.1)
+        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/richtext-slate':
         specifier: 'catalog:'
-        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@react-spring/web':
         specifier: 'catalog:'
         version: 9.7.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+        version: 8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1)
       airtable:
         specifier: 'catalog:'
         version: 0.12.2(encoding@0.1.13)
@@ -740,7 +743,7 @@ importers:
         version: 6.6.0(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       payload:
         specifier: 'catalog:'
-        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
       prop-types:
         specifier: 'catalog:'
         version: 15.8.1
@@ -825,7 +828,7 @@ importers:
         version: link:../../packages/eslint-config-commons-ui
       eslint-import-resolver-webpack:
         specifier: 'catalog:'
-        version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+        version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
@@ -1057,7 +1060,7 @@ importers:
         version: 5.6.3
       webpack:
         specifier: 'catalog:'
-        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   apps/climatemappedafrica:
     dependencies:
@@ -1102,25 +1105,25 @@ importers:
         version: 15.1.4
       '@payloadcms/bundler-webpack':
         specifier: 'catalog:'
-        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(sass@1.69.4)
+        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(sass@1.69.4)
       '@payloadcms/db-mongodb':
         specifier: 'catalog:'
-        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-cloud-storage':
         specifier: 'catalog:'
-        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-nested-docs':
         specifier: 'catalog:'
-        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-sentry':
         specifier: 'catalog:'
-        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)
+        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/plugin-seo':
         specifier: 'catalog:'
-        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)
+        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/richtext-slate':
         specifier: 'catalog:'
-        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reactour/tour':
         specifier: 'catalog:'
         version: 3.7.0(react@18.3.1)
@@ -1150,7 +1153,7 @@ importers:
         version: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)
       next-images:
         specifier: 'catalog:'
-        version: 1.8.5(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 1.8.5(webpack@5.96.1)
       next-seo:
         specifier: 'catalog:'
         version: 6.6.0(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1159,7 +1162,7 @@ importers:
         version: 5.4.1
       payload:
         specifier: 'catalog:'
-        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
       plaiceholder:
         specifier: 'catalog:'
         version: 2.5.0(sharp@0.33.5)
@@ -1219,7 +1222,7 @@ importers:
         version: 3.0.1(video.js@8.19.1)
       webpack:
         specifier: 'catalog:'
-        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
       xlsx:
         specifier: 'catalog:'
         version: 0.18.5
@@ -1259,7 +1262,7 @@ importers:
         version: 8.4.1(@babel/preset-env@7.26.0(@babel/core@7.26.0))(prettier@3.3.3)
       '@storybook/nextjs':
         specifier: 'catalog:'
-        version: 8.4.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)(storybook@8.4.1(prettier@3.3.3))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 8.4.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)(storybook@8.4.1(prettier@3.3.3))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.96.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 8.4.1(@storybook/test@8.4.1(storybook@8.4.1(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.1(prettier@3.3.3))(typescript@5.6.3)
@@ -1283,7 +1286,7 @@ importers:
         version: 29.7.0(@babel/core@7.26.0)
       babel-loader:
         specifier: 'catalog:'
-        version: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1)
       eslint:
         specifier: 'catalog:'
         version: 9.18.0(jiti@1.21.6)
@@ -1295,7 +1298,7 @@ importers:
         version: 5.3.2(@babel/core@7.26.0)(babel-plugin-module-resolver@5.0.2)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-module-resolver:
         specifier: 'catalog:'
         version: 1.5.0
@@ -1334,7 +1337,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       svg-url-loader:
         specifier: 'catalog:'
-        version: 8.0.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 8.0.0(webpack@5.96.1)
       tsx:
         specifier: 'catalog:'
         version: 4.19.2
@@ -1527,7 +1530,7 @@ importers:
         version: 5.6.3
       webpack:
         specifier: 'catalog:'
-        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   apps/pesayetu:
     dependencies:
@@ -1808,6 +1811,9 @@ importers:
       '@mui/material':
         specifier: catalog:mui-styles
         version: 5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/private-theming':
+        specifier: catalog:mui-styles
+        version: 5.16.6(@types/react@18.3.12)(react@18.3.1)
       '@mui/styles':
         specifier: catalog:mui-styles
         version: 5.16.7(@types/react@18.3.12)(react@18.3.1)
@@ -2100,7 +2106,7 @@ importers:
         version: 9.18.0(jiti@1.21.6)
       eslint-config-next:
         specifier: 'catalog:'
-        version: 15.1.4(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
+        version: 15.1.4(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
       eslint-config-prettier:
         specifier: 'catalog:'
         version: 9.1.0(eslint@9.18.0(jiti@1.21.6))
@@ -2224,7 +2230,7 @@ importers:
         version: 9.18.0(jiti@1.21.6)
       eslint-config-next:
         specifier: 'catalog:'
-        version: 15.1.4(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
+        version: 15.1.4(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
       eslint-config-prettier:
         specifier: 'catalog:'
         version: 9.1.0(eslint@9.18.0(jiti@1.21.6))
@@ -18199,50 +18205,6 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
-  '@payloadcms/bundler-webpack@1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(sass@1.69.4)':
-    dependencies:
-      ajv: 8.17.1
-      compression: 1.7.4
-      connect-history-api-fallback: 1.6.0
-      css-loader: 5.2.7(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      file-loader: 6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      find-node-modules: 2.1.3
-      html-webpack-plugin: 5.6.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      md5: 2.3.0
-      mini-css-extract-plugin: 1.6.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      path-browserify: 1.0.1
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      postcss: 8.4.31
-      postcss-loader: 6.2.1(postcss@8.4.31)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      postcss-preset-env: 9.0.0(postcss@8.4.31)
-      process: 0.11.10
-      sass-loader: 12.6.0(sass@1.69.4)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      style-loader: 2.0.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      swc-loader: 0.2.6(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      swc-minify-webpack-plugin: 2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-      webpack-bundle-analyzer: 4.10.2
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      webpack-dev-middleware: 6.1.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      webpack-hot-middleware: 2.26.1
-    transitivePeerDependencies:
-      - '@rspack/core'
-      - '@swc/core'
-      - '@webpack-cli/generators'
-      - '@webpack-cli/migrate'
-      - bufferutil
-      - esbuild
-      - fibers
-      - node-sass
-      - sass
-      - sass-embedded
-      - supports-color
-      - uglify-js
-      - utf-8-validate
-      - webpack-dev-server
-
   '@payloadcms/bundler-webpack@1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(sass@1.69.4)':
     dependencies:
       ajv: 8.17.1
@@ -18266,7 +18228,7 @@ snapshots:
       swc-minify-webpack-plugin: 2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
       webpack-bundle-analyzer: 4.10.2
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       webpack-dev-middleware: 6.1.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
@@ -18287,22 +18249,49 @@ snapshots:
       - utf-8-validate
       - webpack-dev-server
 
-  '@payloadcms/db-mongodb@1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))':
+  '@payloadcms/bundler-webpack@1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(sass@1.69.4)':
     dependencies:
-      bson-objectid: 2.0.4
-      deepmerge: 4.3.1
-      get-port: 5.1.1
-      http-status: 1.6.2
-      mongoose: 6.12.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
-      mongoose-aggregate-paginate-v2: 1.0.6
-      mongoose-paginate-v2: 1.7.22
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      prompts: 2.4.2
-      uuid: 9.0.0
+      ajv: 8.17.1
+      compression: 1.7.4
+      connect-history-api-fallback: 1.6.0
+      css-loader: 5.2.7(webpack@5.96.1)
+      file-loader: 6.2.0(webpack@5.96.1)
+      find-node-modules: 2.1.3
+      html-webpack-plugin: 5.6.3(webpack@5.96.1)
+      md5: 2.3.0
+      mini-css-extract-plugin: 1.6.2(webpack@5.96.1)
+      path-browserify: 1.0.1
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
+      postcss: 8.4.31
+      postcss-loader: 6.2.1(postcss@8.4.31)(webpack@5.96.1)
+      postcss-preset-env: 9.0.0(postcss@8.4.31)
+      process: 0.11.10
+      sass-loader: 12.6.0(sass@1.69.4)(webpack@5.96.1)
+      style-loader: 2.0.0(webpack@5.96.1)
+      swc-loader: 0.2.6(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1)
+      swc-minify-webpack-plugin: 2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1))(webpack@5.96.1)
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
+      webpack-bundle-analyzer: 4.10.2
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
+      webpack-dev-middleware: 6.1.2(webpack@5.96.1)
+      webpack-hot-middleware: 2.26.1
     transitivePeerDependencies:
-      - '@aws-sdk/client-sso-oidc'
-      - aws-crt
+      - '@rspack/core'
+      - '@swc/core'
+      - '@webpack-cli/generators'
+      - '@webpack-cli/migrate'
+      - bufferutil
+      - esbuild
+      - fibers
+      - node-sass
+      - sass
+      - sass-embedded
       - supports-color
+      - uglify-js
+      - utf-8-validate
+      - webpack-dev-server
 
   '@payloadcms/db-mongodb@1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
     dependencies:
@@ -18321,21 +18310,29 @@ snapshots:
       - aws-crt
       - supports-color
 
+  '@payloadcms/db-mongodb@1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))':
+    dependencies:
+      bson-objectid: 2.0.4
+      deepmerge: 4.3.1
+      get-port: 5.1.1
+      http-status: 1.6.2
+      mongoose: 6.12.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))
+      mongoose-aggregate-paginate-v2: 1.0.6
+      mongoose-paginate-v2: 1.7.22
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
+      prompts: 2.4.2
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
+      - aws-crt
+      - supports-color
+
   '@payloadcms/live-preview-react@0.2.0(react@18.3.1)':
     dependencies:
       '@payloadcms/live-preview': 0.2.2
       react: 18.3.1
 
   '@payloadcms/live-preview@0.2.2': {}
-
-  '@payloadcms/plugin-cloud-storage@1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))':
-    dependencies:
-      find-node-modules: 2.1.3
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      range-parser: 1.2.1
-    optionalDependencies:
-      '@aws-sdk/client-s3': 3.685.0
-      '@aws-sdk/lib-storage': 3.685.0(@aws-sdk/client-s3@3.685.0)
 
   '@payloadcms/plugin-cloud-storage@1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
     dependencies:
@@ -18346,23 +18343,22 @@ snapshots:
       '@aws-sdk/client-s3': 3.685.0
       '@aws-sdk/lib-storage': 3.685.0(@aws-sdk/client-s3@3.685.0)
 
-  '@payloadcms/plugin-nested-docs@1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))':
+  '@payloadcms/plugin-cloud-storage@1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))':
     dependencies:
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      find-node-modules: 2.1.3
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
+      range-parser: 1.2.1
+    optionalDependencies:
+      '@aws-sdk/client-s3': 3.685.0
+      '@aws-sdk/lib-storage': 3.685.0(@aws-sdk/client-s3@3.685.0)
 
   '@payloadcms/plugin-nested-docs@1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
     dependencies:
       payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
-  '@payloadcms/plugin-sentry@0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react@18.3.1)':
+  '@payloadcms/plugin-nested-docs@1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))':
     dependencies:
-      '@sentry/node': 7.119.2
-      '@sentry/types': 7.119.2
-      express: 4.21.1
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      react: 18.3.1
-    transitivePeerDependencies:
-      - supports-color
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
 
   '@payloadcms/plugin-sentry@0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)':
     dependencies:
@@ -18374,22 +18370,32 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@payloadcms/plugin-seo@2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react@18.3.1)':
+  '@payloadcms/plugin-sentry@0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)':
     dependencies:
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      '@sentry/node': 7.119.2
+      '@sentry/types': 7.119.2
+      express: 4.21.1
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
       react: 18.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@payloadcms/plugin-seo@2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)':
     dependencies:
       payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       react: 18.3.1
 
-  '@payloadcms/richtext-slate@1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@payloadcms/plugin-seo@2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)':
+    dependencies:
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
+      react: 18.3.1
+
+  '@payloadcms/richtext-slate@1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@faceless-ui/modal': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       i18next: 22.5.1
       is-hotkey: 0.2.0
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       react: 18.3.1
       react-i18next: 11.18.6(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       slate: 0.91.4
@@ -18400,12 +18406,12 @@ snapshots:
       - react-dom
       - react-native
 
-  '@payloadcms/richtext-slate@1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@payloadcms/richtext-slate@1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@faceless-ui/modal': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       i18next: 22.5.1
       is-hotkey: 0.2.0
-      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      payload: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
       react: 18.3.1
       react-i18next: 11.18.6(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       slate: 0.91.4
@@ -18424,21 +18430,6 @@ snapshots:
   '@playwright/test@1.48.2':
     dependencies:
       playwright: 1.48.2
-
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
-    dependencies:
-      ansi-html: 0.0.9
-      core-js-pure: 3.39.0
-      error-stack-parser: 2.1.4
-      html-entities: 2.5.2
-      loader-utils: 2.0.4
-      react-refresh: 0.14.2
-      schema-utils: 4.2.0
-      source-map: 0.7.4
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-    optionalDependencies:
-      type-fest: 4.26.1
-      webpack-hot-middleware: 2.26.1
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.96.1(esbuild@0.24.0))':
     dependencies:
@@ -18465,7 +18456,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.2.0
       source-map: 0.7.4
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     optionalDependencies:
       type-fest: 4.26.1
       webpack-hot-middleware: 2.26.1
@@ -18719,7 +18710,7 @@ snapshots:
       '@sentry/utils': 7.119.2
       localforage: 1.10.0
 
-  '@sentry/nextjs@8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))':
+  '@sentry/nextjs@8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1)':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/instrumentation-http': 0.53.0(@opentelemetry/api@1.9.0)
@@ -18733,7 +18724,7 @@ snapshots:
       '@sentry/types': 8.36.0
       '@sentry/utils': 8.36.0
       '@sentry/vercel-edge': 8.36.0
-      '@sentry/webpack-plugin': 2.22.6(encoding@0.1.13)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      '@sentry/webpack-plugin': 2.22.6(encoding@0.1.13)(webpack@5.96.1)
       chalk: 3.0.0
       next: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)
       resolve: 1.22.8
@@ -18904,22 +18895,12 @@ snapshots:
       '@sentry/types': 8.36.0
       '@sentry/utils': 8.36.0
 
-  '@sentry/webpack-plugin@2.22.6(encoding@0.1.13)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))':
-    dependencies:
-      '@sentry/bundler-plugin-core': 2.22.6(encoding@0.1.13)
-      unplugin: 1.0.1
-      uuid: 9.0.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-
   '@sentry/webpack-plugin@2.22.6(encoding@0.1.13)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
     dependencies:
       '@sentry/bundler-plugin-core': 2.22.6(encoding@0.1.13)
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -18929,7 +18910,7 @@ snapshots:
       '@sentry/bundler-plugin-core': 2.22.6(encoding@0.1.13)
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -19437,23 +19418,23 @@ snapshots:
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.1
       constants-browserify: 1.0.0
-      css-loader: 6.11.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      css-loader: 6.11.0(webpack@5.96.1)
       es-module-lexer: 1.5.4
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      html-webpack-plugin: 5.6.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.6.3)(webpack@5.96.1)
+      html-webpack-plugin: 5.6.3(webpack@5.96.1)
       magic-string: 0.30.12
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
       storybook: 8.4.1(prettier@3.3.3)
-      style-loader: 3.3.4(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      style-loader: 3.3.4(webpack@5.96.1)
+      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-      webpack-dev-middleware: 6.1.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+      webpack-dev-middleware: 6.1.3(webpack@5.96.1)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -19646,7 +19627,7 @@ snapshots:
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
 
-  '@storybook/nextjs@8.4.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)(storybook@8.4.1(prettier@3.3.3))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
+  '@storybook/nextjs@8.4.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(babel-plugin-macros@3.1.0)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)(storybook@8.4.1(prettier@3.3.3))(type-fest@4.26.1)(typescript@5.6.3)(webpack-hot-middleware@2.26.1)(webpack@5.96.1)':
     dependencies:
       '@babel/core': 7.26.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.0)
@@ -19661,31 +19642,31 @@ snapshots:
       '@babel/preset-react': 7.25.9(@babel/core@7.26.0)
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.0)
       '@babel/runtime': 7.26.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.15(react-refresh@0.14.2)(type-fest@4.26.1)(webpack-hot-middleware@2.26.1)(webpack@5.96.1)
       '@storybook/builder-webpack5': 8.4.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(storybook@8.4.1(prettier@3.3.3))(typescript@5.6.3)
       '@storybook/preset-react-webpack': 8.4.1(@storybook/test@8.4.1(storybook@8.4.1(prettier@3.3.3)))(@swc/core@1.8.0(@swc/helpers@0.5.15))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.1(prettier@3.3.3))(typescript@5.6.3)
       '@storybook/react': 8.4.1(@storybook/test@8.4.1(storybook@8.4.1(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.1(prettier@3.3.3))(typescript@5.6.3)
       '@storybook/test': 8.4.1(storybook@8.4.1(prettier@3.3.3))
       '@types/node': 22.8.7
       '@types/semver': 7.5.8
-      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      css-loader: 6.11.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      babel-loader: 9.2.1(@babel/core@7.26.0)(webpack@5.96.1)
+      css-loader: 6.11.0(webpack@5.96.1)
       find-up: 5.0.0
       image-size: 1.1.1
       loader-utils: 3.3.1
       next: 15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.96.1)
       pnp-webpack-plugin: 1.7.0(typescript@5.6.3)
       postcss: 8.4.47
-      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      postcss-loader: 8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.96.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(sass@1.69.4)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      sass-loader: 13.3.3(sass@1.69.4)(webpack@5.96.1)
       semver: 7.6.3
       storybook: 8.4.1(prettier@3.3.3)
-      style-loader: 3.3.4(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      style-loader: 3.3.4(webpack@5.96.1)
       styled-jsx: 5.1.6(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1)
       ts-dedent: 2.2.0
       tsconfig-paths: 4.2.0
@@ -19693,7 +19674,7 @@ snapshots:
     optionalDependencies:
       sharp: 0.33.5
       typescript: 5.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -19851,7 +19832,7 @@ snapshots:
     dependencies:
       '@storybook/core-webpack': 8.4.1(storybook@8.4.1(prettier@3.3.3))
       '@storybook/react': 8.4.1(@storybook/test@8.4.1(storybook@8.4.1(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.1(prettier@3.3.3))(typescript@5.6.3)
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.96.1)
       '@types/node': 22.8.7
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -19863,7 +19844,7 @@ snapshots:
       semver: 7.6.3
       storybook: 8.4.1(prettier@3.3.3)
       tsconfig-paths: 4.2.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     optionalDependencies:
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -19932,20 +19913,6 @@ snapshots:
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
-    dependencies:
-      debug: 4.3.7
-      endent: 2.1.0
-      find-cache-dir: 3.3.2
-      flat-cache: 3.2.0
-      micromatch: 4.0.8
-      react-docgen-typescript: 2.2.2(typescript@5.6.3)
-      tslib: 2.8.1
-      typescript: 5.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-    transitivePeerDependencies:
-      - supports-color
-
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.6.3)(webpack@5.96.1(esbuild@0.24.0))':
     dependencies:
       debug: 4.3.7
@@ -19970,7 +19937,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.6.3)
       tslib: 2.8.1
       typescript: 5.6.3
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - supports-color
 
@@ -20908,31 +20875,31 @@ snapshots:
 
   '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
     dependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack@5.96.1))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))(webpack@5.96.1)':
     dependencies:
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
   '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
     dependencies:
       envinfo: 7.14.0
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack@5.96.1))':
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
     dependencies:
       envinfo: 7.14.0
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
   '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
     dependencies:
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack@5.96.1))':
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)':
     dependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
   '@wry/caches@1.0.1':
     dependencies:
@@ -21314,13 +21281,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
-    dependencies:
-      '@babel/core': 7.26.0
-      find-cache-dir: 4.0.0
-      schema-utils: 4.2.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-
   babel-loader@9.2.1(@babel/core@7.26.0)(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       '@babel/core': 7.26.0
@@ -21333,7 +21293,7 @@ snapshots:
       '@babel/core': 7.26.0
       find-cache-dir: 4.0.0
       schema-utils: 4.2.0
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -22110,20 +22070,6 @@ snapshots:
       postcss-selector-parser: 6.1.2
       postcss-value-parser: 4.2.0
 
-  css-loader@5.2.7(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.4.31)
-      loader-utils: 2.0.4
-      postcss: 8.4.31
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.31)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.31)
-      postcss-modules-scope: 3.2.0(postcss@8.4.31)
-      postcss-modules-values: 4.0.0(postcss@8.4.31)
-      postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
-      semver: 7.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   css-loader@5.2.7(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.31)
@@ -22136,20 +22082,21 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 3.3.0
       semver: 7.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  css-loader@6.11.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
+  css-loader@5.2.7(webpack@5.96.1):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.4.47)
-      postcss: 8.4.47
-      postcss-modules-extract-imports: 3.1.0(postcss@8.4.47)
-      postcss-modules-local-by-default: 4.0.5(postcss@8.4.47)
-      postcss-modules-scope: 3.2.0(postcss@8.4.47)
-      postcss-modules-values: 4.0.0(postcss@8.4.47)
+      icss-utils: 5.1.0(postcss@8.4.31)
+      loader-utils: 2.0.4
+      postcss: 8.4.31
+      postcss-modules-extract-imports: 3.1.0(postcss@8.4.31)
+      postcss-modules-local-by-default: 4.0.5(postcss@8.4.31)
+      postcss-modules-scope: 3.2.0(postcss@8.4.31)
+      postcss-modules-values: 4.0.0(postcss@8.4.31)
       postcss-value-parser: 4.2.0
+      schema-utils: 3.3.0
       semver: 7.6.3
-    optionalDependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   css-loader@6.11.0(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
@@ -22175,7 +22122,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   css-loader@7.1.2(webpack@5.96.1):
     dependencies:
@@ -22989,7 +22936,7 @@ snapshots:
       object.assign: 4.1.5
       object.entries: 1.1.8
 
-  eslint-config-next@15.1.4(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3):
+  eslint-config-next@15.1.4(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3):
     dependencies:
       '@next/eslint-plugin-next': 15.1.4
       '@rushstack/eslint-patch': 1.10.4
@@ -22997,28 +22944,8 @@ snapshots:
       '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-react: 7.37.2(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-react-hooks: 5.1.0(eslint@9.18.0(jiti@1.21.6))
-    optionalDependencies:
-      typescript: 5.6.3
-    transitivePeerDependencies:
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
-  eslint-config-next@15.1.4(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3):
-    dependencies:
-      '@next/eslint-plugin-next': 15.1.4
-      '@rushstack/eslint-patch': 1.10.4
-      '@typescript-eslint/eslint-plugin': 8.12.2(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
-      '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-react: 7.37.2(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.18.0(jiti@1.21.6))
@@ -23079,13 +23006,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -23098,32 +23025,13 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.3.7
-      enhanced-resolve: 5.17.1
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))
-      fast-glob: 3.3.2
-      get-tsconfig: 4.8.1
-      is-bun-module: 1.2.1
-      is-glob: 4.0.3
-    optionalDependencies:
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-node
-      - eslint-import-resolver-webpack
-      - supports-color
-
   eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -23142,7 +23050,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -23161,7 +23069,7 @@ snapshots:
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 9.18.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
@@ -23172,23 +23080,6 @@ snapshots:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      debug: 3.2.7
-      enhanced-resolve: 0.9.1
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
-      find-root: 1.1.0
-      hasown: 2.0.2
-      interpret: 1.4.0
-      is-core-module: 2.15.1
-      is-regex: 1.1.4
-      lodash: 4.17.21
-      resolve: 2.0.0-next.5
-      semver: 5.7.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    transitivePeerDependencies:
       - supports-color
 
   eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
@@ -23204,7 +23095,7 @@ snapshots:
       lodash: 4.17.21
       resolve: 2.0.0-next.5
       semver: 5.7.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - supports-color
 
@@ -23238,7 +23129,7 @@ snapshots:
       lodash: 4.17.21
       resolve: 2.0.0-next.5
       semver: 5.7.2
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23263,30 +23154,7 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
-      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -23298,7 +23166,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
+      eslint: 9.18.0(jiti@1.21.6)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -23310,7 +23189,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -23321,17 +23200,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -23342,36 +23221,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1))(eslint@9.18.0(jiti@1.21.6))
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.8
-      tsconfig-paths: 3.15.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23400,7 +23250,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23429,7 +23279,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23458,7 +23308,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6)))(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23485,7 +23335,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(eslint@9.18.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -23987,23 +23837,23 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   file-loader@6.2.0(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.96.1(esbuild@0.24.0)
+
+  file-loader@6.2.0(webpack@5.96.1):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   file-type@16.5.4:
     dependencies:
@@ -24121,23 +23971,6 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
-    dependencies:
-      '@babel/code-frame': 7.26.2
-      chalk: 4.1.2
-      chokidar: 3.6.0
-      cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
-      fs-extra: 10.1.0
-      memfs: 3.5.3
-      minimatch: 3.1.2
-      node-abort-controller: 3.1.1
-      schema-utils: 3.3.0
-      semver: 7.6.3
-      tapable: 2.2.1
-      typescript: 5.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-
   fork-ts-checker-webpack-plugin@8.0.0(typescript@5.6.3)(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       '@babel/code-frame': 7.26.2
@@ -24170,7 +24003,7 @@ snapshots:
       semver: 7.6.3
       tapable: 2.2.1
       typescript: 5.6.3
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   form-data@2.3.3:
     dependencies:
@@ -24761,15 +24594,6 @@ snapshots:
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.5.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@types/html-minifier-terser': 6.1.0
-      html-minifier-terser: 6.1.0
-      lodash: 4.17.21
-      pretty-error: 4.0.0
-      tapable: 2.2.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   html-webpack-plugin@5.5.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
@@ -24777,16 +24601,15 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  html-webpack-plugin@5.6.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
+  html-webpack-plugin@5.5.3(webpack@5.96.1):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
-    optionalDependencies:
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   html-webpack-plugin@5.6.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
@@ -24797,7 +24620,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   html-webpack-plugin@5.6.3(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
@@ -24817,7 +24640,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -26636,18 +26459,18 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  mini-css-extract-plugin@1.6.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-      webpack-sources: 1.4.3
-
   mini-css-extract-plugin@1.6.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+      webpack-sources: 1.4.3
+
+  mini-css-extract-plugin@1.6.2(webpack@5.96.1):
+    dependencies:
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
       webpack-sources: 1.4.3
 
   minimalistic-assert@1.0.1: {}
@@ -26850,17 +26673,17 @@ snapshots:
     optionalDependencies:
       nodemailer: 6.9.15
 
-  next-images@1.8.5(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
-    dependencies:
-      file-loader: 6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-
   next-images@1.8.5(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       file-loader: 6.2.0(webpack@5.96.1(esbuild@0.24.0))
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1(esbuild@0.24.0)))(webpack@5.96.1(esbuild@0.24.0))
       webpack: 5.96.1(esbuild@0.24.0)
+
+  next-images@1.8.5(webpack@5.96.1):
+    dependencies:
+      file-loader: 6.2.0(webpack@5.96.1)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.96.1))(webpack@5.96.1)
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   next-seo@6.6.0(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -26966,35 +26789,6 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
-    dependencies:
-      assert: 2.1.0
-      browserify-zlib: 0.2.0
-      buffer: 6.0.3
-      console-browserify: 1.2.0
-      constants-browserify: 1.0.0
-      crypto-browserify: 3.12.1
-      domain-browser: 4.23.0
-      events: 3.3.0
-      filter-obj: 2.0.2
-      https-browserify: 1.0.0
-      os-browserify: 0.3.0
-      path-browserify: 1.0.1
-      process: 0.11.10
-      punycode: 2.3.1
-      querystring-es3: 0.2.1
-      readable-stream: 4.5.2
-      stream-browserify: 3.0.0
-      stream-http: 3.2.0
-      string_decoder: 1.3.0
-      timers-browserify: 2.0.12
-      tty-browserify: 0.0.1
-      type-fest: 2.19.0
-      url: 0.11.4
-      util: 0.12.5
-      vm-browserify: 1.1.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-
   node-polyfill-webpack-plugin@2.0.1(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       assert: 2.1.0
@@ -27051,7 +26845,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   node-releases@2.0.18: {}
 
@@ -27452,107 +27246,6 @@ snapshots:
 
   pause@0.0.1: {}
 
-  payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@date-io/date-fns': 2.16.0(date-fns@2.30.0)
-      '@dnd-kit/core': 6.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@faceless-ui/modal': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@faceless-ui/scroll-info': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@faceless-ui/window-info': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@monaco-editor/react': 4.5.1(monaco-editor@0.38.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
-      '@swc/register': 0.1.10(@swc/core@1.6.1(@swc/helpers@0.5.15))
-      body-parser: 1.20.2
-      body-scroll-lock: 4.0.0-beta.0
-      bson-objectid: 2.0.4
-      compression: 1.7.4
-      conf: 10.2.0
-      connect-history-api-fallback: 1.6.0
-      console-table-printer: 2.11.2
-      dataloader: 2.2.2
-      date-fns: 2.30.0
-      deep-equal: 2.2.2
-      deepmerge: 4.3.1
-      dotenv: 8.6.0
-      express: 4.21.0
-      express-fileupload: 1.4.0
-      express-rate-limit: 5.5.1
-      file-type: 16.5.4
-      find-up: 4.1.0
-      fs-extra: 10.1.0
-      get-tsconfig: 4.6.2
-      graphql: 16.8.1
-      graphql-http: 1.21.0(graphql@16.8.1)
-      graphql-playground-middleware-express: 1.7.23(express@4.21.0)
-      graphql-query-complexity: 0.12.0(graphql@16.8.1)
-      graphql-scalars: 1.22.2(graphql@16.8.1)
-      graphql-type-json: 0.3.2(graphql@16.8.1)
-      html-webpack-plugin: 5.5.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      http-status: 1.6.2
-      i18next: 22.5.1
-      i18next-browser-languagedetector: 6.1.8
-      i18next-http-middleware: 3.3.2
-      is-buffer: 2.0.5
-      is-hotkey: 0.2.0
-      is-plain-object: 5.0.0
-      isomorphic-fetch: 3.0.0(encoding@0.1.13)
-      joi: 17.9.2
-      json-schema-to-typescript: 14.0.5
-      jsonwebtoken: 9.0.1
-      jwt-decode: 3.1.2
-      md5: 2.3.0
-      method-override: 3.0.0
-      minimist: 1.2.8
-      mkdirp: 1.0.4
-      monaco-editor: 0.38.0
-      nodemailer: 6.9.8
-      object-to-formdata: 4.5.1
-      passport: 0.6.0
-      passport-anonymous: 1.0.1
-      passport-headerapikey: 1.2.2
-      passport-jwt: 4.0.1
-      passport-local: 1.0.0
-      pino: 8.15.0
-      pino-pretty: 10.3.1
-      pluralize: 8.0.0
-      probe-image-size: 6.0.0
-      process: 0.11.10
-      qs: 6.11.2
-      qs-middleware: 1.0.3
-      react: 18.3.1
-      react-animate-height: 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-datepicker: 4.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-diff-viewer-continued: 3.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-dom: 18.3.1(react@18.3.1)
-      react-helmet: 6.1.0(react@18.3.1)
-      react-i18next: 11.18.6(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-image-crop: 10.1.8(react@18.3.1)
-      react-router-dom: 5.3.4(react@18.3.1)
-      react-router-navigation-prompt: 1.9.6(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
-      react-select: 5.7.4(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-toastify: 10.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      sanitize-filename: 1.6.3
-      sass: 1.69.4
-      scheduler: 0.23.0
-      scmp: 2.1.0
-      sharp: 0.33.5
-      swc-loader: 0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      terser-webpack-plugin: 5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      ts-essentials: 7.0.3(typescript@5.6.3)
-      use-context-selector: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.0)
-      uuid: 9.0.1
-    transitivePeerDependencies:
-      - '@swc/helpers'
-      - '@types/react'
-      - encoding
-      - esbuild
-      - react-native
-      - supports-color
-      - typescript
-      - uglify-js
-      - webpack
-
   payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@date-io/date-fns': 2.16.0(date-fns@2.30.0)
@@ -27640,6 +27333,107 @@ snapshots:
       sharp: 0.33.5
       swc-loader: 0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       terser-webpack-plugin: 5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      ts-essentials: 7.0.3(typescript@5.6.3)
+      use-context-selector: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.0)
+      uuid: 9.0.1
+    transitivePeerDependencies:
+      - '@swc/helpers'
+      - '@types/react'
+      - encoding
+      - esbuild
+      - react-native
+      - supports-color
+      - typescript
+      - uglify-js
+      - webpack
+
+  payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1):
+    dependencies:
+      '@date-io/date-fns': 2.16.0(date-fns@2.30.0)
+      '@dnd-kit/core': 6.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable': 7.0.2(@dnd-kit/core@6.0.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      '@faceless-ui/modal': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@faceless-ui/scroll-info': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@faceless-ui/window-info': 2.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@monaco-editor/react': 4.5.1(monaco-editor@0.38.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
+      '@swc/register': 0.1.10(@swc/core@1.6.1(@swc/helpers@0.5.15))
+      body-parser: 1.20.2
+      body-scroll-lock: 4.0.0-beta.0
+      bson-objectid: 2.0.4
+      compression: 1.7.4
+      conf: 10.2.0
+      connect-history-api-fallback: 1.6.0
+      console-table-printer: 2.11.2
+      dataloader: 2.2.2
+      date-fns: 2.30.0
+      deep-equal: 2.2.2
+      deepmerge: 4.3.1
+      dotenv: 8.6.0
+      express: 4.21.0
+      express-fileupload: 1.4.0
+      express-rate-limit: 5.5.1
+      file-type: 16.5.4
+      find-up: 4.1.0
+      fs-extra: 10.1.0
+      get-tsconfig: 4.6.2
+      graphql: 16.8.1
+      graphql-http: 1.21.0(graphql@16.8.1)
+      graphql-playground-middleware-express: 1.7.23(express@4.21.0)
+      graphql-query-complexity: 0.12.0(graphql@16.8.1)
+      graphql-scalars: 1.22.2(graphql@16.8.1)
+      graphql-type-json: 0.3.2(graphql@16.8.1)
+      html-webpack-plugin: 5.5.3(webpack@5.96.1)
+      http-status: 1.6.2
+      i18next: 22.5.1
+      i18next-browser-languagedetector: 6.1.8
+      i18next-http-middleware: 3.3.2
+      is-buffer: 2.0.5
+      is-hotkey: 0.2.0
+      is-plain-object: 5.0.0
+      isomorphic-fetch: 3.0.0(encoding@0.1.13)
+      joi: 17.9.2
+      json-schema-to-typescript: 14.0.5
+      jsonwebtoken: 9.0.1
+      jwt-decode: 3.1.2
+      md5: 2.3.0
+      method-override: 3.0.0
+      minimist: 1.2.8
+      mkdirp: 1.0.4
+      monaco-editor: 0.38.0
+      nodemailer: 6.9.8
+      object-to-formdata: 4.5.1
+      passport: 0.6.0
+      passport-anonymous: 1.0.1
+      passport-headerapikey: 1.2.2
+      passport-jwt: 4.0.1
+      passport-local: 1.0.0
+      pino: 8.15.0
+      pino-pretty: 10.3.1
+      pluralize: 8.0.0
+      probe-image-size: 6.0.0
+      process: 0.11.10
+      qs: 6.11.2
+      qs-middleware: 1.0.3
+      react: 18.3.1
+      react-animate-height: 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-datepicker: 4.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-diff-viewer-continued: 3.2.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet: 6.1.0(react@18.3.1)
+      react-i18next: 11.18.6(i18next@22.5.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-image-crop: 10.1.8(react@18.3.1)
+      react-router-dom: 5.3.4(react@18.3.1)
+      react-router-navigation-prompt: 1.9.6(react-router-dom@5.3.4(react@18.3.1))(react@18.3.1)
+      react-select: 5.7.4(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react-toastify: 10.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      sanitize-filename: 1.6.3
+      sass: 1.69.4
+      scheduler: 0.23.0
+      scmp: 2.1.0
+      sharp: 0.33.5
+      swc-loader: 0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1)
+      terser-webpack-plugin: 5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1)
       ts-essentials: 7.0.3(typescript@5.6.3)
       use-context-selector: 1.4.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.23.0)
       uuid: 9.0.1
@@ -27899,32 +27693,21 @@ snapshots:
       '@csstools/utilities': 1.0.0(postcss@8.4.31)
       postcss: 8.4.31
 
-  postcss-loader@6.2.1(postcss@8.4.31)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      cosmiconfig: 7.1.0
-      klona: 2.0.6
-      postcss: 8.4.31
-      semver: 7.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   postcss-loader@6.2.1(postcss@8.4.31)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       cosmiconfig: 7.1.0
       klona: 2.0.6
       postcss: 8.4.31
       semver: 7.6.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
+  postcss-loader@6.2.1(postcss@8.4.31)(webpack@5.96.1):
     dependencies:
-      cosmiconfig: 9.0.0(typescript@5.6.3)
-      jiti: 1.21.6
-      postcss: 8.4.47
+      cosmiconfig: 7.1.0
+      klona: 2.0.6
+      postcss: 8.4.31
       semver: 7.6.3
-    optionalDependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-    transitivePeerDependencies:
-      - typescript
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   postcss-loader@8.1.1(postcss@8.4.47)(typescript@5.6.3)(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
@@ -27944,7 +27727,7 @@ snapshots:
       postcss: 8.4.47
       semver: 7.6.3
     optionalDependencies:
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     transitivePeerDependencies:
       - typescript
 
@@ -28992,26 +28775,19 @@ snapshots:
     dependencies:
       truncate-utf8-bytes: 1.0.2
 
-  sass-loader@12.6.0(sass@1.69.4)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      klona: 2.0.6
-      neo-async: 2.6.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    optionalDependencies:
-      sass: 1.69.4
-
   sass-loader@12.6.0(sass@1.69.4)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     optionalDependencies:
       sass: 1.69.4
 
-  sass-loader@13.3.3(sass@1.69.4)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
+  sass-loader@12.6.0(sass@1.69.4)(webpack@5.96.1):
     dependencies:
+      klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
     optionalDependencies:
       sass: 1.69.4
 
@@ -29025,7 +28801,7 @@ snapshots:
   sass-loader@13.3.3(sass@1.69.4)(webpack@5.96.1):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     optionalDependencies:
       sass: 1.69.4
 
@@ -29579,21 +29355,17 @@ snapshots:
       '@tokenizer/token': 0.3.0
       peek-readable: 4.1.0
 
-  style-loader@2.0.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      loader-utils: 2.0.4
-      schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   style-loader@2.0.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  style-loader@3.3.4(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
+  style-loader@2.0.0(webpack@5.96.1):
     dependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      loader-utils: 2.0.4
+      schema-utils: 3.3.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   style-loader@3.3.4(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
@@ -29601,7 +29373,7 @@ snapshots:
 
   style-loader@3.3.4(webpack@5.96.1):
     dependencies:
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   style-to-object@0.4.4:
     dependencies:
@@ -29639,15 +29411,15 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svg-url-loader@8.0.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
-    dependencies:
-      file-loader: 6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-
   svg-url-loader@8.0.0(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
       file-loader: 6.2.0(webpack@5.96.1(esbuild@0.24.0))
       webpack: 5.96.1(esbuild@0.24.0)
+
+  svg-url-loader@8.0.0(webpack@5.96.1):
+    dependencies:
+      file-loader: 6.2.0(webpack@5.96.1)
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   svgo@3.3.2:
     dependencies:
@@ -29659,37 +29431,37 @@ snapshots:
       csso: 5.0.5
       picocolors: 1.1.1
 
-  swc-loader@0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-
   swc-loader@0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@swc/core': 1.6.1(@swc/helpers@0.5.15)
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  swc-loader@0.2.6(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
+  swc-loader@0.2.3(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1):
     dependencies:
-      '@swc/core': 1.8.0(@swc/helpers@0.5.15)
-      '@swc/counter': 0.1.3
+      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   swc-loader@0.2.6(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@swc/core': 1.8.0(@swc/helpers@0.5.15)
       '@swc/counter': 0.1.3
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  swc-minify-webpack-plugin@2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
+  swc-loader@0.2.6(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1):
     dependencies:
       '@swc/core': 1.8.0(@swc/helpers@0.5.15)
+      '@swc/counter': 0.1.3
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   swc-minify-webpack-plugin@2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@swc/core': 1.8.0(@swc/helpers@0.5.15)
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+
+  swc-minify-webpack-plugin@2.1.3(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1):
+    dependencies:
+      '@swc/core': 1.8.0(@swc/helpers@0.5.15)
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   swr@2.2.5(react@18.3.1):
     dependencies:
@@ -29742,17 +29514,6 @@ snapshots:
 
   term-size@2.2.1: {}
 
-  terser-webpack-plugin@5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@swc/core': 1.8.0(@swc/helpers@0.5.15)
-
   terser-webpack-plugin@5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -29760,7 +29521,18 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+    optionalDependencies:
+      '@swc/core': 1.8.0(@swc/helpers@0.5.15)
+
+  terser-webpack-plugin@5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.36.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
     optionalDependencies:
       '@swc/core': 1.8.0(@swc/helpers@0.5.15)
 
@@ -29784,17 +29556,6 @@ snapshots:
       terser: 5.36.0
       webpack: 5.96.1
 
-  terser-webpack-plugin@5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.25
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.2
-      terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    optionalDependencies:
-      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
-
   terser-webpack-plugin@5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
@@ -29802,7 +29563,18 @@ snapshots:
       schema-utils: 3.3.0
       serialize-javascript: 6.0.2
       terser: 5.36.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+    optionalDependencies:
+      '@swc/core': 1.6.1(@swc/helpers@0.5.15)
+
+  terser-webpack-plugin@5.3.9(@swc/core@1.6.1(@swc/helpers@0.5.15))(webpack@5.96.1):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.25
+      jest-worker: 27.5.1
+      schema-utils: 3.3.0
+      serialize-javascript: 6.0.2
+      terser: 5.36.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
     optionalDependencies:
       '@swc/core': 1.6.1(@swc/helpers@0.5.15)
 
@@ -30236,21 +30008,12 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      loader-utils: 2.0.4
-      mime-types: 2.1.35
-      schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-    optionalDependencies:
-      file-loader: 6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-
   url-loader@4.1.1(file-loader@6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
@@ -30262,6 +30025,15 @@ snapshots:
       webpack: 5.96.1(esbuild@0.24.0)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.96.1(esbuild@0.24.0))
+
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.96.1))(webpack@5.96.1):
+    dependencies:
+      loader-utils: 2.0.4
+      mime-types: 2.1.35
+      schema-utils: 3.3.0
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.96.1)
 
   url-parse@1.5.10:
     dependencies:
@@ -31034,24 +30806,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack@5.96.1))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack@5.96.1))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack@5.96.1))
-      colorette: 2.0.20
-      commander: 7.2.0
-      cross-spawn: 7.0.3
-      fastest-levenshtein: 1.0.16
-      import-local: 3.2.0
-      interpret: 2.2.0
-      rechoir: 0.7.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
-      webpack-merge: 5.10.0
-    optionalDependencies:
-      webpack-bundle-analyzer: 4.10.2
-
   webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
@@ -31065,20 +30819,28 @@ snapshots:
       import-local: 3.2.0
       interpret: 2.2.0
       rechoir: 0.7.1
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
       webpack-merge: 5.10.0
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
 
-  webpack-dev-middleware@6.1.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)):
+  webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1):
     dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))(webpack@5.96.1)
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
       colorette: 2.0.20
-      memfs: 3.5.3
-      mime-types: 2.1.35
-      range-parser: 1.2.1
-      schema-utils: 4.2.0
-    optionalDependencies:
+      commander: 7.2.0
+      cross-spawn: 7.0.3
+      fastest-levenshtein: 1.0.16
+      import-local: 3.2.0
+      interpret: 2.2.0
+      rechoir: 0.7.1
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
+      webpack-merge: 5.10.0
+    optionalDependencies:
+      webpack-bundle-analyzer: 4.10.2
 
   webpack-dev-middleware@6.1.2(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
@@ -31088,9 +30850,9 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
-  webpack-dev-middleware@6.1.3(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
+  webpack-dev-middleware@6.1.2(webpack@5.96.1):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -31098,7 +30860,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
 
   webpack-dev-middleware@6.1.3(webpack@5.96.1(esbuild@0.24.0)):
     dependencies:
@@ -31118,7 +30880,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.2.0
     optionalDependencies:
-      webpack: 5.96.1
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -31173,7 +30935,7 @@ snapshots:
       - esbuild
       - uglify-js
 
-  webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))):
+  webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.6
@@ -31198,8 +30960,6 @@ snapshots:
       terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       watchpack: 2.4.2
       webpack-sources: 3.2.3
-    optionalDependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -31227,11 +30987,11 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      terser-webpack-plugin: 5.3.10(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack@5.96.1)
       watchpack: 2.4.2
       webpack-sources: 3.2.3
     optionalDependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,8 +349,8 @@ catalogs:
       specifier: ^2.4.6
       version: 2.4.6
     formik-mui:
-      specifier: ^5.0.0-alpha.1
-      version: 5.0.0-alpha.1
+      specifier: ^4.0.0
+      version: 4.0.0
     formik-mui-lab:
       specifier: ^1.0.0
       version: 1.0.0
@@ -831,7 +831,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       identity-obj-proxy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -1503,7 +1503,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       identity-obj-proxy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -1738,7 +1738,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(esbuild@0.24.0))
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-module-resolver:
         specifier: 'catalog:'
         version: 1.5.0
@@ -1837,7 +1837,7 @@ importers:
         version: 2.4.6(react@18.3.1)
       formik-mui:
         specifier: 'catalog:'
-        version: 5.0.0-alpha.1(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react@18.3.1)(tiny-warning@1.0.3)
+        version: 4.0.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react@18.3.1)(tiny-warning@1.0.3)
       formik-mui-lab:
         specifier: 'catalog:'
         version: 1.0.0(ggufnrxx63oy5h7baag2v3l5wi)
@@ -1925,7 +1925,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       identity-obj-proxy:
         specifier: 'catalog:'
         version: 3.0.0
@@ -1994,31 +1994,31 @@ importers:
         version: 15.1.4(next@15.1.4(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)
       '@payloadcms/bundler-webpack':
         specifier: 'catalog:'
-        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(sass@1.69.4)
+        version: 1.0.7(@swc/core@1.8.0(@swc/helpers@0.5.15))(ajv@8.17.1)(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(sass@1.69.4)
       '@payloadcms/db-mongodb':
         specifier: 'catalog:'
-        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.7.3(@aws-sdk/client-sso-oidc@3.682.0(@aws-sdk/client-sts@3.682.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/live-preview-react':
         specifier: 'catalog:'
         version: 0.2.0(react@18.3.1)
       '@payloadcms/plugin-cloud-storage':
         specifier: 'catalog:'
-        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.2.0(@aws-sdk/client-s3@3.685.0)(@aws-sdk/lib-storage@3.685.0(@aws-sdk/client-s3@3.685.0))(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-nested-docs':
         specifier: 'catalog:'
-        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+        version: 1.0.12(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))
       '@payloadcms/plugin-sentry':
         specifier: 'catalog:'
-        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)
+        version: 0.0.6(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/plugin-seo':
         specifier: 'catalog:'
-        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react@18.3.1)
+        version: 2.3.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react@18.3.1)
       '@payloadcms/richtext-slate':
         specifier: 'catalog:'
-        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 1.5.2(payload@2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 8.36.0(@opentelemetry/core@1.27.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.54.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.27.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.1.4(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.69.4))(react@18.3.1)(webpack@5.96.1)
       ace-builds:
         specifier: 'catalog:'
         version: 1.36.3
@@ -2045,7 +2045,7 @@ importers:
         version: 1.0.3
       payload:
         specifier: 'catalog:'
-        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 2.30.0(@swc/helpers@0.5.15)(@types/react@18.3.12)(encoding@0.1.13)(typescript@5.6.3)(webpack@5.96.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -2115,7 +2115,7 @@ importers:
         version: 3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
       eslint-import-resolver-webpack:
         specifier: 'catalog:'
-        version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+        version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
         version: 2.31.0(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
@@ -2239,7 +2239,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       eslint-plugin-mdx:
         specifier: 'catalog:'
         version: 3.1.5(eslint@9.18.0(jiti@1.21.6))
@@ -2357,7 +2357,7 @@ importers:
         version: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
       eslint-plugin-import:
         specifier: 'catalog:'
-        version: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+        version: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       prettier:
         specifier: 'catalog:'
         version: 3.3.3
@@ -9513,10 +9513,12 @@ packages:
       react: '>=17.0.2'
       tiny-warning: '>=1.0.3'
 
-  formik-mui@5.0.0-alpha.1:
-    resolution: {integrity: sha512-sHzrQwAWdVuKOdI0Xe1kCzXSjKXr50Jcot+szLc64SPw06J4DqwXN3GNxbhvfyEBGJBIL36e+cSSbm2i++tqqg==}
+  formik-mui@4.0.0:
+    resolution: {integrity: sha512-1IzYE83t/Hz05XMQuqs3i/yL7vteqCtjwJDXPBKtomzbif96OrTB2dFk26XEBJaB6ogmtKcxLogrtex3pbOp2A==}
     peerDependencies:
-      '@mui/material': '>5.6.0'
+      '@emotion/react': '>=11.4.1'
+      '@emotion/styled': '>=11.3.0'
+      '@mui/material': '>=5.0.0'
       formik: '>=2.2.9'
       react: '>=17.0.2'
       tiny-warning: '>=1.0.3'
@@ -20873,33 +20875,33 @@ snapshots:
       '@webassemblyjs/ast': 1.12.1
       '@xtuc/long': 4.2.2
 
-  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
-    dependencies:
-      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-
   '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))(webpack@5.96.1)':
     dependencies:
       webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))(webpack-cli@4.10.0)
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
-  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
+  '@webpack-cli/configtest@1.2.0(webpack-cli@4.10.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))':
+    dependencies:
+      webpack: 5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+
+  '@webpack-cli/info@1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))':
     dependencies:
       envinfo: 7.14.0
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
   '@webpack-cli/info@1.5.0(webpack-cli@4.10.0)':
     dependencies:
       envinfo: 7.14.0
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
-
-  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))':
-    dependencies:
       webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+
+  '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))':
+    dependencies:
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
 
   '@webpack-cli/serve@1.7.0(webpack-cli@4.10.0)':
     dependencies:
-      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1)
+      webpack-cli: 4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
 
   '@wry/caches@1.0.1':
     dependencies:
@@ -23103,7 +23105,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
       enhanced-resolve: 0.9.1
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       find-root: 1.1.0
       hasown: 2.0.2
       interpret: 1.4.0
@@ -23120,7 +23122,7 @@ snapshots:
     dependencies:
       debug: 3.2.7
       enhanced-resolve: 0.9.1
-      eslint-plugin-import: 2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.12.2(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       find-root: 1.1.0
       hasown: 2.0.2
       interpret: 1.4.0
@@ -23162,7 +23164,7 @@ snapshots:
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
-      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23185,7 +23187,7 @@ snapshots:
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@8.20.0(eslint@9.18.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
-      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23197,16 +23199,6 @@ snapshots:
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.6.3(eslint-import-resolver-webpack@0.13.9)(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@1.21.6))
       eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-webpack: 0.13.9(eslint-plugin-import@2.31.0)(webpack@5.96.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23309,33 +23301,6 @@ snapshots:
       eslint: 9.18.0(jiti@1.21.6)
       eslint-import-resolver-node: 0.3.9
       eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
-      hasown: 2.0.2
-      is-core-module: 2.15.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.0
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.8
-      tsconfig-paths: 3.15.0
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.31.0(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.8
-      array.prototype.findlastindex: 1.2.5
-      array.prototype.flat: 1.3.2
-      array.prototype.flatmap: 1.3.2
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.18.0(jiti@1.21.6)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-webpack@0.13.9)(eslint@9.18.0(jiti@1.21.6))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -24040,8 +24005,10 @@ snapshots:
       react: 18.3.1
       tiny-warning: 1.0.3
 
-  formik-mui@5.0.0-alpha.1(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react@18.3.1)(tiny-warning@1.0.3):
+  formik-mui@4.0.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(formik@2.4.6(react@18.3.1))(react@18.3.1)(tiny-warning@1.0.3):
     dependencies:
+      '@emotion/react': 11.13.3(@types/react@18.3.12)(react@18.3.1)
+      '@emotion/styled': 11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1)
       '@mui/material': 5.16.7(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react@18.3.1))(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       formik: 2.4.6(react@18.3.1)
       react: 18.3.1
@@ -30809,9 +30776,9 @@ snapshots:
   webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15))))
+      '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0)(webpack@5.96.1(@swc/core@1.8.0(@swc/helpers@0.5.15)))
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
       colorette: 2.0.20
       commander: 7.2.0
       cross-spawn: 7.0.3
@@ -30828,8 +30795,8 @@ snapshots:
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
       '@webpack-cli/configtest': 1.2.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))(webpack@5.96.1)
-      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0)
-      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0)
+      '@webpack-cli/info': 1.5.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))
+      '@webpack-cli/serve': 1.7.0(webpack-cli@4.10.0(webpack-bundle-analyzer@4.10.2)(webpack@5.96.1))
       colorette: 2.0.20
       commander: 7.2.0
       cross-spawn: 7.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -119,7 +119,7 @@ catalog:
   fast-equals: ^5.0.1
   form-data: ^4.0.0
   formik: ^2.4.6
-  formik-mui: ^5.0.0-alpha.1
+  formik-mui: ^4.0.0
   formik-mui-lab: ^1.0.0
   googleapis: ^133.0.0
   graphql: ^15.9.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -207,3 +207,4 @@ catalogs:
     "@mui/material": ^5.16.6
     "@mui/styles": ^5.16.6
     "@mui/utils": ^5.16.6
+    "@mui/private-theming": ^5.16.6


### PR DESCRIPTION
## Description

This PR  Fixes issues with Promise Tracker which failed since migration from mui 4.

- [ ] Reverts Formik MUI to v4.0.0 which causes some breaks.
- [ ] Replaces undefined with null for serialization.
- [ ] Adds Promise Tracker builder to docker for easy testing
- [ ] Fixes failing import location for create theme.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
