### PR TITLE
ClimateMappedAfrica: User unable to click the search field

### DIFF
--- a/apps/climatemappedafrica/src/components/HURUmap/Chart/index.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Chart/index.js
@@ -109,8 +109,10 @@ function Chart({
 
   useEffect(() => {
     try {
-      const viewProp = new vega.View(vega.parse(cSpec), { renderer: "none" });
-      setDownloadView(viewProp);
+      if (cSpec) {
+        const viewProp = new vega.View(vega.parse(cSpec), { renderer: "none" });
+        setDownloadView(viewProp);
+      }
     } catch (error) {
       console.error("Error creating view", error);
     }

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/DesktopPanel.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/DesktopPanel.js
@@ -56,10 +56,11 @@ function DesktopPanel({ sx, ...props }) {
             border: "none",
             display: "flex",
             flexDirection: "row",
+            // Setting Drawer persistent causes header to be non sticky. We are setting the height to 100vh - 88px to account for the toolbar height.
             height: "calc(100vh - 88px)", // Toolbar height
             overflowY: "visible",
             position: "relative",
-            top: 0, // Toolbar height
+            top: 0,
           }),
         }}
       >

--- a/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/DesktopPanel.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Panel/DesktopPanel/DesktopPanel.js
@@ -21,6 +21,12 @@ function DesktopPanel({ sx, ...props }) {
   const open = value === "rich-data" && !tutorialOpen;
   return (
     <>
+      <PanelButtons
+        {...props}
+        onValueChange={handleValueChange}
+        open={open}
+        value={value}
+      />
       <Drawer
         anchor="left"
         onClose={closeDrawer}
@@ -41,29 +47,24 @@ function DesktopPanel({ sx, ...props }) {
             overscrollBehaviorBlock: "none",
           },
         }}
+        variant="persistent"
         PaperProps={{
           elevation: 0,
           square: true,
-          sx: ({ typography }) => ({
+          sx: () => ({
             background: "transparent",
             border: "none",
             display: "flex",
             flexDirection: "row",
-            height: "100%",
+            height: "calc(100vh - 88px)", // Toolbar height
             overflowY: "visible",
             position: "relative",
-            top: typography.pxToRem(88), // Toolbar height
+            top: 0, // Toolbar height
           }),
         }}
       >
         <PanelItem {...props} item={{ value: "rich-data" }} />
       </Drawer>
-      <PanelButtons
-        {...props}
-        onValueChange={handleValueChange}
-        open={open}
-        value={value}
-      />
     </>
   );
 }

--- a/packages/commons-ui-next/src/Link/StyledLink.js
+++ b/packages/commons-ui-next/src/Link/StyledLink.js
@@ -74,7 +74,7 @@ const StyledLink = React.forwardRef(function Link(props, ref) {
   } = props;
 
   // https://nextjs.org/docs/app/api-reference/components/link#href-required
-  const url = typeof href === "string" ? href : href.pathname;
+  const url = typeof href === "string" ? href : href?.pathname;
   const isExternal = isExternalUrl(url);
   if (isExternal) {
     const externalLinkProps = {
@@ -117,7 +117,7 @@ const StyledLink = React.forwardRef(function Link(props, ref) {
 StyledLink.propTypes = {
   as: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   className: PropTypes.string,
-  href: PropTypes.string,
+  href: PropTypes.string.isRequired,
   legacyBehavior: PropTypes.bool,
   linkAs: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
   locale: PropTypes.string,


### PR DESCRIPTION
## Description

currently, a user is unable to click input to search a location. This is caused by drawer backdrop which prevents actions on other visible elements even after setting  a greater zIndex.
This PR changes drawer to persistent and updates styles to maintain how it was.

Fixes #1038

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
