### PR TITLE
Switch to styling default `Vega Tooltip`

### DIFF
--- a/apps/climatemappedafrica/src/components/HURUmap/Chart/index.js
+++ b/apps/climatemappedafrica/src/components/HURUmap/Chart/index.js
@@ -1,14 +1,14 @@
 import { RichTypography } from "@commons-ui/next";
-import { ChartTooltip, IndicatorTitle, Download, Share } from "@hurumap/core";
+import { IndicatorTitle, Download, Share } from "@hurumap/core";
 import { Source } from "@hurumap/next";
-import { Box, useMediaQuery, useTheme } from "@mui/material";
-import React, { useState, useRef, useCallback, useEffect } from "react";
+import { Box, GlobalStyles, useMediaQuery, useTheme } from "@mui/material";
+import React, { useState, useRef, useEffect } from "react";
 import * as vega from "vega";
 import embed from "vega-embed";
 
 import configureScope from "./configureScope";
 import Filters from "./Filters";
-import { calculateTooltipPosition, idify } from "./utils";
+import { idify } from "./utils";
 
 import CopyIcon from "@/climatemappedafrica/assets/icons/copy.svg";
 import DownloadIcon from "@/climatemappedafrica/assets/icons/download.svg";
@@ -24,6 +24,58 @@ import projectlogo from "@/climatemappedafrica/assets/logos/projectLogo.svg";
 import config, { hurumapArgs } from "@/climatemappedafrica/config";
 import site from "@/climatemappedafrica/utils/site";
 
+const inputGlobalStyles = (
+  // NOTE: Global style uses default theme https://github.com/mui/material-ui/blob/5f4452348e6669e96c8d9f1c5a791a5154eaed70/packages/mui-material/src/GlobalStyles/GlobalStyles.js#L9
+  <GlobalStyles
+    styles={(theme) => ({
+      // Default theme: https://github.com/vega/vega-tooltip/blob/6aebdc73d783432cd66b5caef4093169064cfff0/vega-tooltip.scss#L1
+      "#vg-tooltip-element": {
+        ...theme.typography.body2,
+        backgroundColor: theme.palette.grey["900"],
+        border: `1px solid ${theme.palette.grey["900"]}`,
+        borderRadius: theme.typography.pxToRem(4),
+        boxShadow: "0px 3px 6px #00000029",
+        color: theme.palette.text.secondary,
+        opacity: 0.8,
+        padding: theme.typography.pxToRem(12.5),
+        zIndex: theme.zIndex.tooltip,
+        // In desktop, charts are rendered on a drawer
+        [theme.breakpoints.up("lg")]: {
+          zIndex: theme.zIndex.drawer + 1,
+        },
+        // HTML structure: https://github.com/vega/vega-tooltip/blob/6aebdc73d783432cd66b5caef4093169064cfff0/src/formatValue.ts#L9
+        table: {
+          tbody: {
+            display: "flex",
+            alignItems: "space-between",
+            tr: {
+              display: "flex",
+              // flex: "50%",
+              marginRight: theme.typography.pxToRem(12.5),
+              "&:last-of-type": {
+                marginRight: 0,
+              },
+              td: {
+                padding: 0,
+                "&.key": {
+                  display: "none",
+                },
+                "&.value": {
+                  maxHeith: undefined,
+                  maxWidth: theme.typography.pxToRem(148),
+                },
+              },
+            },
+          },
+        },
+      },
+      ".custom-theme": {
+        // Extra/new styles
+      },
+    })}
+  />
+);
+
 function Chart({
   indicator,
   indicatorTitle,
@@ -35,11 +87,9 @@ function Chart({
   ...props
 }) {
   const chartRef = useRef();
-  const tooltipRef = useRef();
   const [view, setView] = useState(null);
   const [cSpec, setCSpec] = useState(null);
   const isMobile = !useMediaQuery("(min-width:600px)");
-  const [tooltipData, setTooltipData] = useState(null);
   const { palette } = useTheme();
   const [downloadView, setDownloadView] = useState(null);
   const secondaryIndicator = sI?.indicator;
@@ -65,13 +115,6 @@ function Chart({
     view.signal("Units", value.toLowerCase()).run();
   };
 
-  const handler = useCallback(
-    (_, event, item, value) => {
-      setTooltipData({ item, value, id, geoCode, event });
-    },
-    [id, geoCode],
-  );
-
   useEffect(() => {
     async function renderChart() {
       const spec = configureScope(
@@ -88,7 +131,7 @@ function Chart({
             actions: false,
             padding: 0,
             renderer: "canvas",
-            tooltip: handler,
+            tooltip: { theme: "custom" },
           });
 
           setView(newView.view);
@@ -98,14 +141,7 @@ function Chart({
       }
     }
     renderChart();
-  }, [
-    indicator,
-    isMobile,
-    isCompare,
-    profileNames,
-    secondaryIndicator,
-    handler,
-  ]);
+  }, [indicator, isMobile, isCompare, profileNames, secondaryIndicator]);
 
   useEffect(() => {
     try {
@@ -173,15 +209,6 @@ function Chart({
       }),
   ];
 
-  let position = {};
-  if (tooltipData?.event && tooltipRef?.current) {
-    position = calculateTooltipPosition(
-      tooltipData?.event,
-      tooltipRef?.current?.getBoundingClientRect(),
-      0,
-      10,
-    );
-  }
   if (!indicator?.data) {
     return null;
   }
@@ -315,86 +342,72 @@ function Chart({
   ];
 
   return (
-    <Box
-      id={`chart-${id}-${geoCode}`}
-      sx={({ typography }) => ({
-        position: "relative",
-        width: "100%",
-        "&:last-of-type": {
-          marginBottom: typography.pxToRem(32),
-        },
-      })}
-    >
-      <IndicatorTitle
-        title={title}
-        description={description}
-        view={view}
-        geoCode={geoCode}
-        indicatorId={id}
-        disableToggle={disableToggle}
-        chartValue={chartValue}
-        handleChartValueChange={onChartValueChange}
-        spec={cSpec}
-        currentFilters={currentFilters}
-        source={source}
-        isCompare={isCompare}
-        profileNames={profileNames}
-        chartType={chartType?.toLowerCase()}
-        actions={actions}
-      >
-        {indicatorTitle}
-      </IndicatorTitle>
-      {!isMobile && (
-        <Filters
-          filterGroups={filterGroups}
-          filterSelectProps={filterSelectProps}
-          setFilterSelectProps={setFilterSelectProps}
-          defaultFilters={defaultFilters ?? undefined}
-          view={view}
-        />
-      )}
+    <>
+      {inputGlobalStyles}
       <Box
-        ref={chartRef}
-        sx={{
-          width: "100%",
-        }}
-      />
-      <RichTypography
-        variant="body2"
-        sx={(theme) => ({
-          color: "#666666",
-          fontSize: theme.typography.pxToRem(13),
-          lineHeight: 20 / 13,
-        })}
-      >
-        {description}
-      </RichTypography>
-      <Source
-        href={url}
+        id={`chart-${id}-${geoCode}`}
         sx={({ typography }) => ({
-          margin: `${typography.pxToRem(20)} 0`,
+          position: "relative",
+          width: "100%",
+          "&:last-of-type": {
+            marginBottom: typography.pxToRem(32),
+          },
         })}
       >
-        {source}
-      </Source>
-      {tooltipData && tooltipData?.event && (
-        <ChartTooltip
-          id={id}
+        <IndicatorTitle
+          title={title}
+          description={description}
+          view={view}
           geoCode={geoCode}
-          value={tooltipData.value}
-          itemColor={tooltipData.item?.fill}
-          event={tooltipData?.event}
-          title={tooltipData.value?.group}
-          tooltipRef={tooltipRef}
-          position={position}
-          formattedValue={
-            defaultType?.toLowerCase() === "percentage" || !disableToggle
-              ? tooltipData.value?.percentage
-              : undefined
-          }
+          indicatorId={id}
+          disableToggle={disableToggle}
+          chartValue={chartValue}
+          handleChartValueChange={onChartValueChange}
+          spec={cSpec}
+          currentFilters={currentFilters}
+          source={source}
+          isCompare={isCompare}
+          profileNames={profileNames}
+          chartType={chartType?.toLowerCase()}
+          actions={actions}
+        >
+          {indicatorTitle}
+        </IndicatorTitle>
+        {!isMobile && (
+          <Filters
+            filterGroups={filterGroups}
+            filterSelectProps={filterSelectProps}
+            setFilterSelectProps={setFilterSelectProps}
+            defaultFilters={defaultFilters ?? undefined}
+            view={view}
+          />
+        )}
+        <Box
+          ref={chartRef}
+          sx={{
+            width: "100%",
+          }}
         />
-      )}
-    </Box>
+        <RichTypography
+          variant="body2"
+          sx={(theme) => ({
+            color: "#666666",
+            fontSize: theme.typography.pxToRem(13),
+            lineHeight: 20 / 13,
+          })}
+        >
+          {description}
+        </RichTypography>
+        <Source
+          href={url}
+          sx={({ typography }) => ({
+            margin: `${typography.pxToRem(20)} 0`,
+          })}
+        >
+          {source}
+        </Source>
+      </Box>
+    </>
   );
 }
 


### PR DESCRIPTION
## Description

Our current approach of creating a React-based Tooltip leads to a lot of complications (portals, hooks, etc.) as well as performance issues (unnecessary re-renders, etc.) without any benefits to show for. This PR sticks to the HTML-based Vega Tooltip and styles it to match the site design.

This approach seems to yield a much simpler code and better performance.

**NOTE**: Only the basic tooltip style is implemented in this PR as a proof that we don't need the complicated approach. The remaining tooltip style(s) should be implemented after this PR has been reviewed and accepted.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore

## Screenshots

### This PR

https://github.com/user-attachments/assets/173d91bb-ebc2-44c1-96e6-cff4e62fd0fa

### Current live site

https://github.com/user-attachments/assets/b32a3324-4785-435a-a287-9821791746a4


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
