### PR TITLE
Fix `climatemappedafrica` `ArticlePage`

### DIFF
--- a/apps/civicsignalblog/src/components/ArticleHeader/ArticleHeader.js
+++ b/apps/civicsignalblog/src/components/ArticleHeader/ArticleHeader.js
@@ -29,7 +29,7 @@ const ArticleHeader = React.forwardRef(function ArticleHeader(props, ref) {
         {date}
       </RichTypography>
       <RichTypography
-        component="div"
+        component="h1"
         variant="h1"
         sx={{ mt: { xs: 2.5, md: 5 } }}
       >

--- a/apps/civicsignalblog/src/components/ArticlePage/ArticlePage.js
+++ b/apps/civicsignalblog/src/components/ArticlePage/ArticlePage.js
@@ -104,7 +104,7 @@ function ArticlePage({
                   sm: "648px",
                   md: "912px",
                 },
-                mb: { xs: 2.5, md: 7.5 },
+                pb: { xs: 2.5, md: 7.5 },
                 px: { xs: 2.5, sm: 0 },
               }}
             >
@@ -116,6 +116,11 @@ function ArticlePage({
                     key={tag.slug}
                     component={Link}
                     href={`/${primaryTag}?tag=${tag.slug}`}
+                    sx={{
+                      "& .MuiChip-label": {
+                        padding: 0,
+                      },
+                    }}
                   />
                 ))}
               </ChoiceChipGroup>

--- a/apps/civicsignalblog/src/components/ArticlePage/ArticlePage.snap.js
+++ b/apps/civicsignalblog/src/components/ArticlePage/ArticlePage.snap.js
@@ -28,11 +28,11 @@ exports[`<ArticlePage /> renders unchanged 1`] = `
       >
         Sept 1, 2021
       </div>
-      <div
+      <h1
         class="MuiTypography-root MuiTypography-h1 css-16gyjy8-MuiTypography-root"
       >
         Article
-      </div>
+      </h1>
       <div
         class="MuiStack-root css-yhfzs2-MuiStack-root"
       >
@@ -147,14 +147,14 @@ exports[`<ArticlePage /> renders unchanged 1`] = `
       />
     </div>
     <div
-      class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-1fwha7w-MuiContainer-root"
+      class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-2bn17z-MuiContainer-root"
     >
       <div
         class="MuiToggleButtonGroup-root css-1ie26o5-MuiToggleButtonGroup-root"
         role="group"
       >
         <a
-          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-1463e5x-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiChip-root"
+          class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiChip-root MuiChip-filled MuiChip-sizeMedium MuiChip-colorDefault MuiChip-clickable MuiChip-clickableColorDefault MuiChip-filledDefault css-pnh8h-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiChip-root"
           href="/tag1?tag=tag2"
           tabindex="0"
           value="tag2"

--- a/apps/codeforafrica/src/components/ArticleHeader/ArticleHeader.js
+++ b/apps/codeforafrica/src/components/ArticleHeader/ArticleHeader.js
@@ -29,7 +29,7 @@ const ArticleHeader = React.forwardRef(function ArticleHeader(props, ref) {
         {date}
       </RichTypography>
       <RichTypography
-        component="div"
+        component="h1"
         variant="h1"
         sx={{ mt: { xs: 2.5, md: 5 } }}
       >

--- a/apps/codeforafrica/src/components/ArticlePage/ArticlePage.snap.js
+++ b/apps/codeforafrica/src/components/ArticlePage/ArticlePage.snap.js
@@ -28,11 +28,11 @@ exports[`<ArticlePage /> renders unchanged 1`] = `
       >
         Sept 1, 2021
       </div>
-      <div
+      <h1
         class="MuiTypography-root MuiTypography-h1 css-3hsw5e-MuiTypography-root"
       >
         Article
-      </div>
+      </h1>
       <div
         class="MuiStack-root css-yhfzs2-MuiStack-root"
       >

--- a/apps/techlabblog/components/PostHeader/PostHeader.tsx
+++ b/apps/techlabblog/components/PostHeader/PostHeader.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import type { PostProps } from "@/techlabblog/components/Post";
 
-const PostHeader = React.forwardRef(function ArticleHeader(
+const PostHeader = React.forwardRef(function PostHeader(
   props: PostProps,
   ref: React.Ref<HTMLDivElement>,
 ) {


### PR DESCRIPTION
## Description

- [x] Ensure `h1` component is used in the header (required/recommended for better SEO)
- [ ] Ensure there is adequate spacing between `ArticlePage` and `Footer`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

![s](https://github.com/user-attachments/assets/f1b657f5-c6ec-4a72-bb27-40a2bff1d072)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
