### PR TITLE
Enhance Build Reliability (ClimateMap)

### DIFF
--- a/apps/climatemappedafrica/next.config.js
+++ b/apps/climatemappedafrica/next.config.js
@@ -26,6 +26,7 @@ module.exports = {
     },
   },
   reactStrictMode: false,
+  staticPageGenerationTimeout: 180,
   transpilePackages: [
     "@commons-ui/core",
     "@commons-ui/next",


### PR DESCRIPTION
## Description

During the static build process of ClimateMap, approximately 57 pages need to be pre-rendered, each requiring data from the HURUMap API. To address intermittent build failures caused by API response delays, this PR implements two key improvements:

1. Increases the static page generation timeout from 60s to 180s to accommodate longer API response times
2. Implements a retry mechanism with exponential backoff for failed API requests, making the build process more resilient. If all retries are exhausted, we provide fallback content.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
