### PR TITLE
Improve `@/trustlab` setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -954,6 +954,7 @@ COPY apps/trustlab ./apps/trustlab
 RUN --mount=type=secret,id=mongo_url,env=MONGO_URL \
   --mount=type=secret,id=payload_secret,env=PAYLOAD_SECRET \
   --mount=type=secret,id=sentry_auth_token,env=SENTRY_AUTH_TOKEN \
+  --mount=type=secret,id=smtp_pass,env=SMTP_PASS \
   pnpm --filter trustlab build
 
 #
@@ -961,11 +962,6 @@ RUN --mount=type=secret,id=mongo_url,env=MONGO_URL \
 # -----------------------------------------
 
 FROM base-runner AS trustlab-runner
-
-# RUN set -ex \
-#   # Create nextjs cache dir w/ correct permissions
-#   && mkdir -p ./apps/trustlab/.next \
-#   && chown nextjs:nodejs ./apps/trustlab/.next
 
 # PNPM
 # symlink some dependencies

--- a/apps/trustlab/src/payload/plugins/index.js
+++ b/apps/trustlab/src/payload/plugins/index.js
@@ -4,6 +4,12 @@ import { seoPlugin } from "@payloadcms/plugin-seo";
 import { s3Storage } from "@payloadcms/storage-s3";
 import * as Sentry from "@sentry/nextjs";
 
+const accessKeyId = process.env.S3_ACCESS_KEY_ID ?? "";
+const bucket = process.env.S3_BUCKET ?? "";
+const region = process.env.S3_REGION ?? "";
+const secretAccessKey = process.env.S3_SECRET_ACCESS_KEY ?? "";
+const s3Enabled = !!accessKeyId && !!region && !!secretAccessKey;
+
 const plugins = [
   nestedDocsPlugin({
     collections: ["pages"],
@@ -14,14 +20,15 @@ const plugins = [
     collections: {
       media: true,
     },
-    bucket: process.env.S3_BUCKET ?? "",
+    bucket,
     config: {
       credentials: {
-        accessKeyId: process.env.S3_ACCESS_KEY_ID ?? "",
-        secretAccessKey: process.env.S3_SECRET_ACCESS_KEY ?? "",
+        accessKeyId,
+        secretAccessKey,
       },
-      region: process.env.S3_REGION ?? "",
+      region,
     },
+    enabled: s3Enabled,
   }),
   sentryPlugin({
     options: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,13 +189,20 @@ services:
 
   trustlab:
     build:
+      # env_file attribute is for runtime
+      # We need args to be available at build time & hence we need to
+      # specify them here; they come from --env-file command-line argument(s)
       args:
+        - NEXT_PUBLIC_APP_URL=${NEXT_PUBLIC_APP_URL}
         - SENTRY_ENVIRONMENT="local"
+        - SMTP_HOST=${SMTP_HOST}
+        - SMTP_USER=${SMTP_USER}
       context: .
       secrets:
         - mongo_url
         - payload_secret
         - sentry_auth_token
+        - smtp_pass
       target: trustlab-runner
     env_file:
       - path: ./apps/trustlab/.env
@@ -266,5 +273,7 @@ secrets:
     environment: PAYLOAD_SECRET
   sentry_auth_token:
     environment: SENTRY_AUTH_TOKEN
+  smtp_pass:
+    environment: SMTP_PASS
 volumes:
   db_data:

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -14,5 +14,5 @@
       "@/commons-ui/payload/*": ["./packages/commons-ui-payload/src/*"]
     }
   },
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "**/node_modules/*"]
 }

--- a/scripts/dc.sh
+++ b/scripts/dc.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 
 APP="$1"
-APP_ENV_FILE="./apps/${APP}/.env.local"
 REPO_SHA=$(git log --pretty=format:'%h' --max-count=1)
-set -a
-source "${APP_ENV_FILE}"  # Load the environment variables from the .env.local file
-set +a
 
-# Don't override IMAGE_TAG, BUILDKIT_PROGRESS, etc. if already set
-IMAGE_TAG=${IMAGE_TAG-${REPO_SHA}} \
-BUILDKIT_PROGRESS=${BUILDKIT_PROGRESS-plain} \
-docker compose --env-file "${APP_ENV_FILE}" \
-  up "${APP}" --build
+# Don't override IMAGE_TAG and BUILDKIT_PROGRESS if already set.
+# `compose` now supports multiple `--env-file` args
+# see:
+#   https://github.com/docker/compose/releases/tag/v2.17.0-rc.1
+# verify via:
+#   `docker compose --env-file ./apps/trustlab/.env --env-file ./apps/trustlab/.env.local config --environment`
+IMAGE_TAG=${IMAGE_TAG:-${REPO_SHA}} \
+  BUILDKIT_PROGRESS=${BUILDKIT_PROGRESS:-plain} \
+  docker compose \
+  --env-file "./apps/${APP}/.env" \
+  --env-file "./apps/${APP}/.env.local" \
+  up "${APP}"


### PR DESCRIPTION
## Description

+ [x] Enable S3 storage only when necessary env vars are set, otherwise use local `media` folder (for development).
+ [x] Switch SMTP_PASS to be a secret instead of regular arg/env.
+ [x] `compose` now supports multiple `--env-file` args and hence no need to `source` env file(s) manually.

## Type of change

- [ ] Chore

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
