### PR TITLE
Fix isPageHeader bug

### DIFF
--- a/apps/trustlab/src/payload/blocks/PageHeader.js
+++ b/apps/trustlab/src/payload/blocks/PageHeader.js
@@ -4,9 +4,17 @@ const PageHeader = BannerBlock(
   "page-header",
   "/images/cms/blocks/page-header.png",
   {
-    hooks: {
-      afterRead: [({ doc }) => ({ ...doc, isPageHeader: true })],
-    },
+    fields: [
+      {
+        name: "isPageHeader",
+        type: "checkbox",
+        defaultValue: true,
+        virtual: true,
+        admin: {
+          hidden: true,
+        },
+      },
+    ],
   },
 );
 


### PR DESCRIPTION
## Description

[`Blocks`](https://payloadcms.com/docs/fields/blocks#block-configs) do not support hooks. Only `Fields`, `Globals` and `Collections` do.
This PR fixes a bug where we used `afterRead` to update the `isPageHeader` field by using a [virtual field](https://payloadcms.com/docs/fields/checkbox#:~:text=a%20JSON%20schema-,virtual,-Provide%20true%20to) to ensure that the value is not saved in the db, but is computed dynamically.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
