### PR TITLE
[QuickFix] Fix `clean` scrip

### DIFF
--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -30,7 +30,7 @@
     "lint": "TIMING=1 eslint --flag unstable_config_lookup_from_file --fix './'",
     "jest": "jest",
     "playwright": "npx playwright test",
-    "clean": "rm -rf .next .turbo node_modules"
+    "clean": "rm -rf .next .turbo build dist node_modules"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "catalog:",

--- a/apps/roboshield/package.json
+++ b/apps/roboshield/package.json
@@ -10,7 +10,7 @@
     "payload-migrate:down": "payload migrate:down",
     "start": "next start",
     "dev": "NODE_OPTIONS='--inspect' next dev",
-    "clean": "rm -rf .next .turbo node_modules",
+    "clean": "rm -rf .next .turbo build dist node_modules",
     "jest": "jest --passWithNoTests",
     "lint-check": "TIMING=1 next lint './'",
     "lint": "TIMING=1 next lint --fix './'",

--- a/apps/trustlab/src/components/MobileNavBar/MobileNavBar.js
+++ b/apps/trustlab/src/components/MobileNavBar/MobileNavBar.js
@@ -5,7 +5,6 @@ import React, { useState } from "react";
 
 // eslint-disable-next-line import/no-unresolved
 import XIcon from "@/trustlab/assets/icons/Type=x, Size=24, Color=currentColor.svg?url";
-// eslint-disable-next-line import/no-unresolved
 import MenuIcon from "@/trustlab/assets/menu-icon.svg?url";
 
 const MobileNavBar = React.forwardRef(function MobileNavBar(props, ref) {


### PR DESCRIPTION
## Description

`pnpm clean` should clean all build directories. This quick fix PR fixes this in `codeforafrica` and `roboshield` where payload build directories were not fixed.

## Type of change

- [x] Chore

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
