### PR TITLE
Trustlab: Refactor postList function to streamline post retrieval.

### DIFF
--- a/apps/trustlab/src/lib/data/blockify/postList.js
+++ b/apps/trustlab/src/lib/data/blockify/postList.js
@@ -15,19 +15,20 @@ async function postList(block, api, context) {
   const { slugs } = params;
   const [page] = slugs;
 
-  let posts = initialPosts;
-  let pagination = {
-    count: initialPosts.length,
-    page: 1,
-  };
+  // afterRead hook doesn't run in the relationship field for selected posts of a block. We are adding this to query the posts by ids so we can have links populated.
+  const options = showAllPosts
+    ? {
+        limit: 9,
+      }
+    : {
+        where: {
+          id: {
+            in: initialPosts.map((post) => post.id).join(","),
+          },
+        },
+      };
+  const { pagination, posts } = await getPosts(api, page, options);
 
-  if (showAllPosts) {
-    const postData = await getPosts(api, page, {
-      limit: 9,
-    });
-    pagination = postData.pagination;
-    posts = postData.posts;
-  }
   return {
     blockType,
     slug: blockType,

--- a/apps/trustlab/src/utils/post.js
+++ b/apps/trustlab/src/utils/post.js
@@ -24,7 +24,7 @@ export async function getPost(api, slug) {
     content[postImageOverviewBlockIndex] = {
       ...content[postImageOverviewBlockIndex],
       date: post.deadline ? formatDate(post.deadline) : null,
-      isClosed: post.deadline && new Date(post.deadline) < new Date(),
+      isClosed: post.deadline ? new Date(post.deadline) < new Date() : null,
     };
   }
   const blocks = [


### PR DESCRIPTION
## Description
afterRead hook doesn't run in the relationship field for selected posts of a block. We are adding this to query the posts by ids so we can have links populated.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
