### PR TITLE
fix(access): remove public read access from Users collections

### DIFF
--- a/apps/civicsignalblog/package.json
+++ b/apps/civicsignalblog/package.json
@@ -1,6 +1,6 @@
 {
   "name": "civicsignalblog",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the (temporary) CivicSignal blog",

--- a/apps/civicsignalblog/src/payload/collections/Users.js
+++ b/apps/civicsignalblog/src/payload/collections/Users.js
@@ -22,7 +22,6 @@ const Users = {
   slug: "users",
   access: {
     create: isAdmin,
-    read: () => true,
     update: isAdminOrSelf,
     delete: isAdminOrSelf,
   },

--- a/apps/climatemappedafrica/package.json
+++ b/apps/climatemappedafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climatemappedafrica",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "ClimateMapped Africa",

--- a/apps/climatemappedafrica/src/payload/collections/Users.js
+++ b/apps/climatemappedafrica/src/payload/collections/Users.js
@@ -9,7 +9,6 @@ const User = {
   slug: "users",
   access: {
     create: isAdmin,
-    read: () => true,
     update: isAdminOrSelf,
     delete: isAdminOrSelf,
   },

--- a/apps/codeforafrica/package.json
+++ b/apps/codeforafrica/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codeforafrica",
-  "version": "1.0.61",
+  "version": "1.0.62",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "This is the main CFA site.",

--- a/apps/codeforafrica/src/payload/collections/Users.js
+++ b/apps/codeforafrica/src/payload/collections/Users.js
@@ -9,7 +9,6 @@ const Users = {
   slug: "users",
   access: {
     create: isAdmin,
-    read: () => true,
     update: isAdminOrSelf,
     delete: isAdminOrSelf,
   },

--- a/apps/roboshield/package.json
+++ b/apps/roboshield/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roboshield",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/roboshield/src/payload/collections/Users.ts
+++ b/apps/roboshield/src/payload/collections/Users.ts
@@ -9,7 +9,6 @@ const Users = {
   slug: "users",
   access: {
     create: isAdmin,
-    read: () => true,
     update: isAdminOrSelf,
     delete: isAdminOrSelf,
   },


### PR DESCRIPTION
## Description

This PR ensures that only logged-in users can view the list of users by using the [default](https://payloadcms.com/docs/access-control/overview#default-access-control) PayloadCMS Access control

Fixes #1269

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
