### PR TITLE
feat: Trustlab Add link button to Rapid Response Helplines

### DIFF
--- a/apps/trustlab/src/components/HelplineCard/HelplineCard.js
+++ b/apps/trustlab/src/components/HelplineCard/HelplineCard.js
@@ -1,37 +1,97 @@
-import Card from "@/trustlab/components/Card";
+import { Link } from "@commons-ui/next";
+import { LexicalRichText } from "@commons-ui/payload";
+import {
+  Card,
+  CardActions,
+  CardContent,
+  CardMedia,
+  Box,
+  Divider,
+  Typography,
+  Button,
+} from "@mui/material";
 
-function HelplineCard({ title, media, description, link, linkLabel }) {
+function HelplineCard({ title, icon: media, description, link }) {
   return (
-    <Card
-      title={title}
-      media={media}
-      description={description}
-      link={link}
-      linkLabel={linkLabel}
-      sx={{
-        padding: 2,
-      }}
-      CardHeaderProps={{
-        sx: {
-          px: 0,
-        },
-      }}
-      CardContentProps={{
-        sx: {
-          px: 0,
-        },
-      }}
-      TitleProps={{
-        sx: {
-          textAlign: "center",
-        },
-      }}
-      CardActionsProps={{
-        sx: {
-          p: 0,
-        },
-      }}
-    />
+    <Card elevation={0} gap={2} key={title}>
+      <Box
+        display="flex"
+        justifyContent="center"
+        alignItems="center"
+        sx={{ p: 0 }}
+      >
+        <CardMedia
+          component="img"
+          image={media?.url}
+          alt={media?.alt}
+          sx={{
+            height: { xs: "108px", md: "180px" },
+            width: { xs: "108px", md: "180px" },
+          }}
+        />
+      </Box>
+      <CardContent sx={{ p: 0 }}>
+        <Box sx={{ width: "100%" }}>
+          <Divider
+            sx={{
+              background: "black",
+              my: 2,
+            }}
+          />
+          <Typography
+            variant="h3"
+            sx={{
+              textDecoration: "none",
+            }}
+          >
+            {title}
+          </Typography>
+          <Divider
+            sx={{
+              background: "black",
+              my: 2,
+            }}
+          />
+        </Box>
+        <LexicalRichText
+          elements={description}
+          TypographyProps={{
+            gutterBottom: true,
+            variant: "p2",
+            sx: {
+              mb: 0,
+              textDecoration: "none",
+            },
+          }}
+        />
+      </CardContent>
+      <CardActions sx={{ p: 0 }}>
+        <Button
+          variant="contained"
+          color="primary"
+          size="small"
+          component={link?.href ? Link : "button"}
+          href={link?.href}
+          sx={{
+            mt: 2,
+            alignSelf: "start",
+            backgroundColor: "#FFDE59",
+            color: "black",
+            height: 32,
+            border: "2px solid black",
+            fontSize: 16,
+            fontWeight: 600,
+            textTransform: "none",
+            "&:hover": {
+              backgroundColor: "#FFDE59",
+              border: "2px solid black",
+            },
+          }}
+        >
+          {link?.label}
+        </Button>
+      </CardActions>
+    </Card>
   );
 }
 

--- a/apps/trustlab/src/components/HelplineCard/HelplineCard.snap.js
+++ b/apps/trustlab/src/components/HelplineCard/HelplineCard.snap.js
@@ -3,45 +3,47 @@
 exports[`<HelplineCard /> renders unchanged 1`] = `
 <div>
   <div
-    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation1 MuiCard-root css-17ti5b3-MuiPaper-root-MuiCard-root"
-    style="--Paper-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);"
+    class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-19ky9kz-MuiPaper-root-MuiCard-root"
+    gap="2"
+    style="--Paper-shadow: none;"
   >
     <div
-      class="MuiCardMedia-root css-1avv2mj-MuiCardMedia-root"
-      role="img"
-      style="background-image: url(/resources-1.jpg);"
-      title="Anti Trolling"
-    />
-    <div
-      class="MuiCardHeader-root css-ofa8v-MuiCardHeader-root"
+      class="MuiBox-root css-u85suh"
     >
-      <div
-        class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
-      >
-        <h2
-          class="MuiTypography-root MuiTypography-h2 css-s9xaj3-MuiTypography-root"
-        >
-          Anti Trolling
-        </h2>
-      </div>
-    </div>
-    <div
-      class="MuiCardContent-root css-yjf187-MuiCardContent-root"
-    >
-      <div
-        class="MuiBox-root css-7x1cxm"
+      <img
+        class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-9uzd9u-MuiCardMedia-root"
       />
     </div>
     <div
-      class="MuiCardActions-root MuiCardActions-spacing css-t9qhmi-MuiCardActions-root"
+      class="MuiCardContent-root css-127evc8-MuiCardContent-root"
     >
-      <a
-        class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-15f3whe-MuiTypography-root-MuiLink-root-MuiButtonBase-root-MuiButton-root"
-        href="/helplines/anti-trolling"
-        tabindex="0"
+      <div
+        class="MuiBox-root css-8atqhb"
       >
-        Get Support
-      </a>
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+        />
+        <h3
+          class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
+        >
+          Anti Trolling
+        </h3>
+        <hr
+          class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+        />
+      </div>
+      <div
+        class="MuiBox-root css-0"
+      />
+    </div>
+    <div
+      class="MuiCardActions-root MuiCardActions-spacing css-jbneu4-MuiCardActions-root"
+    >
+      <button
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
+        tabindex="0"
+        type="button"
+      />
     </div>
   </div>
 </div>

--- a/apps/trustlab/src/components/Helplines/Helplines.js
+++ b/apps/trustlab/src/components/Helplines/Helplines.js
@@ -1,15 +1,8 @@
 import { Section } from "@commons-ui/core";
-import { Figure, Link } from "@commons-ui/next";
-import { LexicalRichText } from "@commons-ui/payload";
-import {
-  Grid2 as Grid,
-  Typography,
-  Stack,
-  Divider,
-  Box,
-  Button,
-} from "@mui/material";
+import { Grid2 as Grid, Typography, Stack, Box } from "@mui/material";
 import React, { forwardRef } from "react";
+
+import HelplineCard from "../HelplineCard";
 
 const Helplines = forwardRef(function Helplines({ title, briefs = [] }, ref) {
   return (
@@ -25,90 +18,12 @@ const Helplines = forwardRef(function Helplines({ title, briefs = [] }, ref) {
             sx={{ ml: -2 }}
             spacing={{
               xs: 2,
-              md: 20,
+              md: 10,
             }}
           >
             {briefs.map((brief) => (
-              <Grid
-                display="flex"
-                alignItems={{
-                  sm: "center",
-                  textDecoration: "none",
-                }}
-                gap={2}
-                size={{ xs: 12, sm: 4 }}
-                key={brief.title}
-                flexDirection="column"
-              >
-                <Figure
-                  ImageProps={{
-                    alt: brief.icon.alt,
-                    src: brief.icon.url,
-                  }}
-                  sx={{
-                    height: { xs: "108px", md: "180px" },
-                    width: { xs: "108px", md: "180px" },
-                    alignSelf: "center",
-                  }}
-                />
-                <Box sx={{ width: "100%" }}>
-                  <Divider
-                    sx={{
-                      background: "black",
-                      mb: 2,
-                    }}
-                  />
-                  <Typography
-                    variant="h3"
-                    sx={{
-                      textDecoration: "none",
-                    }}
-                  >
-                    {brief.title}
-                  </Typography>
-                  <Divider
-                    sx={{
-                      background: "black",
-                      mt: 2,
-                    }}
-                  />
-                </Box>
-
-                <LexicalRichText
-                  elements={brief.description}
-                  TypographyProps={{
-                    gutterBottom: true,
-                    variant: "p2",
-                    sx: {
-                      mb: 0,
-                      textDecoration: "none",
-                    },
-                  }}
-                />
-                <Button
-                  variant="contained"
-                  color="primary"
-                  size="small"
-                  component={brief?.link.href ? Link : "button"}
-                  href={brief?.link.href}
-                  sx={{
-                    mt: 2,
-                    alignSelf: "start",
-                    backgroundColor: "#FFDE59",
-                    color: "black",
-                    height: 32,
-                    border: "2px solid black",
-                    fontSize: 16,
-                    fontWeight: 600,
-                    textTransform: "none",
-                    "&:hover": {
-                      backgroundColor: "#FFDE59",
-                      border: "2px solid black",
-                    },
-                  }}
-                >
-                  {brief?.link?.label}
-                </Button>
+              <Grid key={brief.id} size={{ xs: 12, sm: 4 }}>
+                <HelplineCard {...brief} />
               </Grid>
             ))}
           </Grid>

--- a/apps/trustlab/src/components/Helplines/Helplines.snap.js
+++ b/apps/trustlab/src/components/Helplines/Helplines.snap.js
@@ -17,163 +17,187 @@ exports[`<Helplines /> renders unchanged 1`] = `
           Rapid Response
         </h2>
         <div
-          class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 MuiGrid2-spacing-md-20 css-1eexbq2-MuiGrid2-root"
+          class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-2 MuiGrid2-spacing-md-10 css-ukfad2-MuiGrid2-root"
         >
           <div
-            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-qkbwyb-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-1d5smkg-MuiGrid2-root"
           >
-            <figure
-              class="MuiBox-root css-cqflv1"
-            >
-              <img
-                alt="Rapid Response icon"
-                class="css-qv2885"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=640&q=75 640w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=750&q=75 750w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=828&q=75 828w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1080&q=75 1080w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1200&q=75 1200w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1920&q=75 1920w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=2048&q=75 2048w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </figure>
             <div
-              class="MuiBox-root css-8atqhb"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-7osdb6-MuiDivider-root"
-              />
-              <h3
-                class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
-              >
-                Rapid Response Briefing
-              </h3>
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-i722bu-MuiDivider-root"
-              />
-            </div>
-            <div
-              class="MuiBox-root css-0"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-19ky9kz-MuiPaper-root-MuiCard-root"
+              gap="2"
+              style="--Paper-shadow: none;"
             >
               <div
-                class="payload-richtext"
+                class="MuiBox-root css-u85suh"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                <img
+                  alt="Rapid Response icon"
+                  class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-9uzd9u-MuiCardMedia-root"
+                  src="/api/media/file/screenshot-2025-07-21-at-20830-pm-1.png"
+                />
+              </div>
+              <div
+                class="MuiCardContent-root css-127evc8-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-8atqhb"
                 >
-                  This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
-                </p>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                  <h3
+                    class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
+                  >
+                    Rapid Response Briefing
+                  </h3>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="payload-richtext"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                    >
+                      This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiCardActions-root MuiCardActions-spacing css-jbneu4-MuiCardActions-root"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                />
               </div>
             </div>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            />
           </div>
           <div
-            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-qkbwyb-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-1d5smkg-MuiGrid2-root"
           >
-            <figure
-              class="MuiBox-root css-cqflv1"
-            >
-              <img
-                alt="Rapid Response icon"
-                class="css-qv2885"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=640&q=75 640w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=750&q=75 750w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=828&q=75 828w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1080&q=75 1080w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1200&q=75 1200w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1920&q=75 1920w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=2048&q=75 2048w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </figure>
             <div
-              class="MuiBox-root css-8atqhb"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-7osdb6-MuiDivider-root"
-              />
-              <h3
-                class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
-              >
-                Rapid Response Briefing
-              </h3>
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-i722bu-MuiDivider-root"
-              />
-            </div>
-            <div
-              class="MuiBox-root css-0"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-19ky9kz-MuiPaper-root-MuiCard-root"
+              gap="2"
+              style="--Paper-shadow: none;"
             >
               <div
-                class="payload-richtext"
+                class="MuiBox-root css-u85suh"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                <img
+                  alt="Rapid Response icon"
+                  class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-9uzd9u-MuiCardMedia-root"
+                  src="/api/media/file/screenshot-2025-07-21-at-20830-pm-1.png"
+                />
+              </div>
+              <div
+                class="MuiCardContent-root css-127evc8-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-8atqhb"
                 >
-                  This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
-                </p>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                  <h3
+                    class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
+                  >
+                    Rapid Response Briefing
+                  </h3>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="payload-richtext"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                    >
+                      This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiCardActions-root MuiCardActions-spacing css-jbneu4-MuiCardActions-root"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                />
               </div>
             </div>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            />
           </div>
           <div
-            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-qkbwyb-MuiGrid2-root"
+            class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-4 css-1d5smkg-MuiGrid2-root"
           >
-            <figure
-              class="MuiBox-root css-cqflv1"
-            >
-              <img
-                alt="Rapid Response icon"
-                class="css-qv2885"
-                data-nimg="fill"
-                decoding="async"
-                loading="lazy"
-                sizes="100vw"
-                src="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75"
-                srcset="/_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=640&q=75 640w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=750&q=75 750w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=828&q=75 828w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1080&q=75 1080w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1200&q=75 1200w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=1920&q=75 1920w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=2048&q=75 2048w, /_next/image?url=%2Fapi%2Fmedia%2Ffile%2Fscreenshot-2025-07-21-at-20830-pm-1.png&w=3840&q=75 3840w"
-                style="position: absolute; height: 100%; width: 100%; left: 0px; top: 0px; right: 0px; bottom: 0px; color: transparent;"
-              />
-            </figure>
             <div
-              class="MuiBox-root css-8atqhb"
-            >
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-7osdb6-MuiDivider-root"
-              />
-              <h3
-                class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
-              >
-                Rapid Response Briefing
-              </h3>
-              <hr
-                class="MuiDivider-root MuiDivider-fullWidth css-i722bu-MuiDivider-root"
-              />
-            </div>
-            <div
-              class="MuiBox-root css-0"
+              class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-19ky9kz-MuiPaper-root-MuiCard-root"
+              gap="2"
+              style="--Paper-shadow: none;"
             >
               <div
-                class="payload-richtext"
+                class="MuiBox-root css-u85suh"
               >
-                <p
-                  class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                <img
+                  alt="Rapid Response icon"
+                  class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-9uzd9u-MuiCardMedia-root"
+                  src="/api/media/file/screenshot-2025-07-21-at-20830-pm-1.png"
+                />
+              </div>
+              <div
+                class="MuiCardContent-root css-127evc8-MuiCardContent-root"
+              >
+                <div
+                  class="MuiBox-root css-8atqhb"
                 >
-                  This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
-                </p>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                  <h3
+                    class="MuiTypography-root MuiTypography-h3 css-r9nd4k-MuiTypography-root"
+                  >
+                    Rapid Response Briefing
+                  </h3>
+                  <hr
+                    class="MuiDivider-root MuiDivider-fullWidth css-5tnkj6-MuiDivider-root"
+                  />
+                </div>
+                <div
+                  class="MuiBox-root css-0"
+                >
+                  <div
+                    class="payload-richtext"
+                  >
+                    <p
+                      class="MuiTypography-root MuiTypography-p2 MuiTypography-gutterBottom css-1gwq4gx-MuiTypography-root"
+                    >
+                      This is a placeholder text that should be updated. Trustlab fact-checkers will help debunk false-claims or other smear campaigns against human rights defenders.
+                    </p>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="MuiCardActions-root MuiCardActions-spacing css-jbneu4-MuiCardActions-root"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                />
               </div>
             </div>
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeSmall MuiButton-containedSizeSmall MuiButton-colorPrimary css-1xmfh2b-MuiButtonBase-root-MuiButton-root"
-              tabindex="0"
-              type="button"
-            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description

This PR Adds Link to Rapid response Helplines and improves spacing on large screens

Fixes # (issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
<img width="802" height="335" alt="image" src="https://github.com/user-attachments/assets/b2a76981-dbd3-4e15-92ba-86313f573253" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
