### PR TITLE
fix: Make RowCard image objectFit configurable via parent

### DIFF
--- a/apps/trustlab/src/components/Helplines/Helplines.js
+++ b/apps/trustlab/src/components/Helplines/Helplines.js
@@ -30,6 +30,7 @@ const Helplines = forwardRef(function Helplines(
                   mb: 3,
                   borderTop: "1px solid",
                   borderRadius: 0,
+                  img: { objectFit: "contain" },
                 }}
                 {...brief}
                 image={brief.icon}

--- a/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
+++ b/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
@@ -114,6 +114,7 @@ const PlaybooksList = forwardRef(function PlaybooksList(props, ref) {
                       borderTop: "1px solid #000",
                       borderRadius: 0,
                       py: 2,
+                      img: { objectFit: "cover" },
                     }}
                     actionLabel={cardActionLabel}
                     {...pb}

--- a/apps/trustlab/src/components/PlaybooksList/PlaybooksList.snap.js
+++ b/apps/trustlab/src/components/PlaybooksList/PlaybooksList.snap.js
@@ -21,13 +21,13 @@ exports[`<PlaybooksList /> renders initial playbooks using RowCard 1`] = `
             class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-1j0u08r-MuiGrid2-root"
           >
             <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1k85j6c-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-w7o9cy-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
               href="/playbooks/a"
               id="p1"
               style="--Paper-shadow: none;"
             >
               <div
-                class="MuiBox-root css-1htvg76"
+                class="MuiBox-root css-v98hkk"
               >
                 <img
                   alt="A"
@@ -75,13 +75,13 @@ exports[`<PlaybooksList /> renders initial playbooks using RowCard 1`] = `
             class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 css-1j0u08r-MuiGrid2-root"
           >
             <a
-              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1k85j6c-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
+              class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-w7o9cy-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
               href="/playbooks/b"
               id="p2"
               style="--Paper-shadow: none;"
             >
               <div
-                class="MuiBox-root css-1htvg76"
+                class="MuiBox-root css-v98hkk"
               >
                 <img
                   alt="B"

--- a/apps/trustlab/src/components/RowCard/RowCard.js
+++ b/apps/trustlab/src/components/RowCard/RowCard.js
@@ -61,7 +61,6 @@ const RowCard = forwardRef(function RowCard(props, ref) {
             width: { xs: "100%", sm: 280 },
             position: "relative",
             "& img": {
-              objectFit: "cover",
               height: { xs: 280, md: 220 },
               display: "block",
             },


### PR DESCRIPTION
## Description

Allow parent components to control the objectFit style of RowCard images instead of hardcoding it to "cover". This enables the component to work properly across different contexts (playbooks, helplines, etc.).

Fixes #

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots
Currently:
<img width="312" height="674" alt="image" src="https://github.com/user-attachments/assets/47ddb8ca-34ba-419d-950f-2f1803777400" />
Fixed:
<img width="306" height="621" alt="image" src="https://github.com/user-attachments/assets/503e54eb-3146-46a5-af3c-76ab586dd652" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
