### PR TITLE
feat(trustlab): add search, sort, and filter improvements to ReportsList and OpportunityList

### DIFF
--- a/apps/trustlab/src/components/Filters/Filters.js
+++ b/apps/trustlab/src/components/Filters/Filters.js
@@ -120,18 +120,35 @@ function SortDropdown({ label, options = [], value, onChange }) {
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
         onClose={() => setAnchorEl(null)}
       >
-        {options.map((opt) => (
-          <MenuItem
-            key={opt.value}
-            selected={opt.value === value}
-            onClick={() => {
-              onChange?.(opt.value === value ? null : opt.value);
-              setAnchorEl(null);
-            }}
-          >
-            <ListItemText primary={opt.label} />
-          </MenuItem>
-        ))}
+        {options.map((opt) => {
+          const isSelected = opt.value === value;
+          return (
+            <MenuItem
+              key={opt.value}
+              onClick={() => {
+                onChange?.(isSelected ? null : opt.value);
+                setAnchorEl(null);
+              }}
+              sx={{ minWidth: 160, justifyContent: "space-between", gap: 2 }}
+            >
+              <ListItemText primary={opt.label} />
+              {isSelected && (
+                <SvgIcon
+                  sx={{ fontSize: 16, fill: "none", flexShrink: 0 }}
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M2.5 8 L6.5 12 L13.5 4"
+                    stroke="currentColor"
+                    strokeWidth="1.75"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </SvgIcon>
+              )}
+            </MenuItem>
+          );
+        })}
       </Menu>
     </>
   );
@@ -329,7 +346,16 @@ const Filters = React.forwardRef(function Filters(
 
   return (
     <Box ref={ref} display="flex" flexDirection="column" gap={1} sx={sx}>
-      {/* Row 1: Filter By Label + Filter dropdowns + Search + Sort By */}
+      {/* Filter By label sits above the controls row */}
+      {filterByLabel && (
+        <Typography variant="subtitle1" fontWeight={700}>
+          {filterByLabel}
+        </Typography>
+      )}
+
+      {/* Controls row — flat flex row that wraps.
+          xs: search claims its own line (width 100%), filters + sort wrap below.
+          sm+: search is capped at 50%, everything stays on one line. */}
       <Stack
         direction="row"
         alignItems="center"
@@ -337,33 +363,6 @@ const Filters = React.forwardRef(function Filters(
         useFlexGap
         gap={2}
       >
-        {filterByLabel && (
-          <Typography
-            variant="subtitle1"
-            fontWeight={700}
-            sx={{ flexShrink: 0 }}
-          >
-            {filterByLabel}
-          </Typography>
-        )}
-        {processedFilters.map((filter) => (
-          <FilterDropdown
-            key={filter.type}
-            label={filter.label}
-            options={filter.options}
-            selected={selectedValues[filter.type] || []}
-            onChange={(values) => handleFilterChange(filter.type, values)}
-            getOptionValue={filter.getOptionValue}
-            getOptionLabel={filter.getOptionLabel}
-            startIcon={
-              <SvgIcon
-                component={filter.icon}
-                sx={{ fill: "none", fontSize: "16px" }}
-              />
-            }
-            size="small"
-          />
-        ))}
         {showSearch && (
           <InputBase
             value={searchValue}
@@ -392,9 +391,10 @@ const Filters = React.forwardRef(function Filters(
               </InputAdornment>
             }
             sx={{
-              flex: 1,
+              width: { xs: "100%", sm: "auto" },
+              flex: { sm: 1 },
+              maxWidth: { sm: "50%" },
               minWidth: 180,
-              maxWidth: "45%",
               border: "1px solid #C9CACB",
               borderRadius: "10px",
               px: 1.5,
@@ -404,13 +404,34 @@ const Filters = React.forwardRef(function Filters(
             }}
           />
         )}
-        {showSort && (
-          <SortDropdown
-            label={sortByLabel}
-            options={sortOptions}
-            value={sortValue}
-            onChange={handleSortChange}
+        {processedFilters.map((filter) => (
+          <FilterDropdown
+            key={filter.type}
+            label={filter.label}
+            options={filter.options}
+            selected={selectedValues[filter.type] || []}
+            onChange={(values) => handleFilterChange(filter.type, values)}
+            getOptionValue={filter.getOptionValue}
+            getOptionLabel={filter.getOptionLabel}
+            startIcon={
+              <SvgIcon
+                component={filter.icon}
+                sx={{ fill: "none", fontSize: "16px" }}
+              />
+            }
+            size="small"
           />
+        ))}
+        {/* ml:auto keeps sort at the far right of whichever line it lands on */}
+        {showSort && (
+          <Box sx={{ ml: "auto" }}>
+            <SortDropdown
+              label={sortByLabel}
+              options={sortOptions}
+              value={sortValue}
+              onChange={handleSortChange}
+            />
+          </Box>
         )}
       </Stack>
 

--- a/apps/trustlab/src/components/Filters/Filters.js
+++ b/apps/trustlab/src/components/Filters/Filters.js
@@ -6,6 +6,7 @@ import {
   Chip,
   SvgIcon,
   InputBase,
+  InputAdornment,
   Menu,
   MenuItem,
   ListItemText,
@@ -153,6 +154,8 @@ const Filters = React.forwardRef(function Filters(
     sortByLabel,
     sortOptions = [],
     onSortChange,
+    // Atomic clear (preferred over onApply/onClear when search/sort are active)
+    onClearAll,
   },
   ref,
 ) {
@@ -286,11 +289,15 @@ const Filters = React.forwardRef(function Filters(
     if (searchTimerRef.current) {
       clearTimeout(searchTimerRef.current);
     }
-    onSearch?.("");
-    onSortChange?.(null);
-    onClear?.();
-    onApply?.({});
-  }, [onApply, onClear, onSearch, onSortChange]);
+    if (onClearAll) {
+      // Single atomic call — parent handles state + URL in one router.push
+      onClearAll();
+    } else {
+      // Fallback for consumers that don't use search/sort (no race risk there)
+      onClear?.();
+      onApply?.({});
+    }
+  }, [onApply, onClear, onClearAll]);
 
   const anySelected = useMemo(() => {
     return (
@@ -315,9 +322,10 @@ const Filters = React.forwardRef(function Filters(
     return chips;
   }, [selectedValues, getChipLabel]);
 
-  const showSearch =
-    searchPlaceholderLabel !== undefined && searchPlaceholderLabel !== null;
-  const showSort = sortByLabel && sortOptions.length > 0;
+  // Gate on the callback props so a stale CMS label can't accidentally re-show
+  // a control whose feature flag has been disabled
+  const showSearch = Boolean(onSearch);
+  const showSort = Boolean(onSortChange) && sortOptions.length > 0;
 
   return (
     <Box ref={ref} display="flex" flexDirection="column" gap={1} sx={sx}>
@@ -361,9 +369,32 @@ const Filters = React.forwardRef(function Filters(
             value={searchValue}
             onChange={handleSearchChange}
             placeholder={searchPlaceholderLabel || "Search..."}
+            startAdornment={
+              <InputAdornment position="start" sx={{ ml: 0.5, mr: 0.25 }}>
+                <SvgIcon
+                  sx={{ fontSize: 16, fill: "none", color: "text.secondary" }}
+                  viewBox="0 0 20 20"
+                >
+                  <circle
+                    cx="9"
+                    cy="9"
+                    r="6"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                  />
+                  <path
+                    d="m14 14 3.5 3.5"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                  />
+                </SvgIcon>
+              </InputAdornment>
+            }
             sx={{
               flex: 1,
               minWidth: 180,
+              maxWidth: "45%",
               border: "1px solid #C9CACB",
               borderRadius: "10px",
               px: 1.5,
@@ -415,7 +446,6 @@ const Filters = React.forwardRef(function Filters(
             <Button
               variant="text"
               onClick={clearAll}
-              disabled={!anySelected}
               size="small"
               sx={{
                 textTransform: "none",

--- a/apps/trustlab/src/components/Filters/Filters.js
+++ b/apps/trustlab/src/components/Filters/Filters.js
@@ -1,9 +1,27 @@
-import { Box, Typography, Button, Stack, Chip, SvgIcon } from "@mui/material";
-import React, { useState, useMemo, useCallback } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Stack,
+  Chip,
+  SvgIcon,
+  InputBase,
+  Menu,
+  MenuItem,
+  ListItemText,
+} from "@mui/material";
+import React, {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+} from "react";
 
 import FilterDropdown from "./FilterDropdown";
 
 import CalendarIcon from "@/trustlab/assets/icons/calendar.svg";
+import ChevronDownIcon from "@/trustlab/assets/icons/chevron-down.svg";
 import CloseIcon from "@/trustlab/assets/icons/close.svg";
 import DocumentIcon from "@/trustlab/assets/icons/document.svg";
 
@@ -52,12 +70,105 @@ const monthLabels = [
   "December",
 ];
 
+function SortDropdown({ label, options = [], value, onChange }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+
+  const selectedOption = options.find((o) => o.value === value);
+  const buttonLabel = selectedOption
+    ? `${label}: ${selectedOption.label}`
+    : label;
+
+  return (
+    <>
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={(e) => setAnchorEl(e.currentTarget)}
+        endIcon={
+          <SvgIcon
+            component={ChevronDownIcon}
+            inheritViewBox
+            sx={{ fill: "none", fontSize: 16, display: "block", mt: "-4px" }}
+          />
+        }
+        sx={{
+          textTransform: "none",
+          backgroundColor: "#fff",
+          borderRadius: "10px",
+          border: "1px solid #C9CACB",
+          display: "inline-flex",
+          alignItems: "center",
+          lineHeight: 1,
+          "& .MuiButton-endIcon": {
+            m: 0,
+            display: "inline-flex",
+            alignItems: "center",
+          },
+          "& .MuiButton-endIcon svg": {
+            fontSize: 16,
+            display: "block",
+          },
+        }}
+      >
+        {buttonLabel}
+      </Button>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
+        onClose={() => setAnchorEl(null)}
+      >
+        {options.map((opt) => (
+          <MenuItem
+            key={opt.value}
+            selected={opt.value === value}
+            onClick={() => {
+              onChange?.(opt.value === value ? null : opt.value);
+              setAnchorEl(null);
+            }}
+          >
+            <ListItemText primary={opt.label} />
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}
+
+const SEARCH_DEBOUNCE_MS = 400;
+
 const Filters = React.forwardRef(function Filters(
-  { filterByLabel, filters = [], clearFiltersLabel, onApply, onClear, sx },
+  {
+    filterByLabel,
+    filters = [],
+    clearFiltersLabel,
+    onApply,
+    onClear,
+    sx,
+    // Search
+    searchPlaceholderLabel,
+    onSearch,
+    // Sort
+    sortByLabel,
+    sortOptions = [],
+    onSortChange,
+  },
   ref,
 ) {
-  // Initialize selected state for all filter types
   const [selectedValues, setSelectedValues] = useState({});
+  const [sortValue, setSortValue] = useState(null);
+  const [searchValue, setSearchValue] = useState("");
+  const searchTimerRef = useRef(null);
+
+  // Cleanup debounce timer on unmount
+  useEffect(() => {
+    return () => {
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+    };
+  }, []);
 
   // Process filters config and build options
   const processedFilters = useMemo(() => {
@@ -146,19 +257,48 @@ const Filters = React.forwardRef(function Filters(
     [selectedValues, handleFilterChange],
   );
 
+  const handleSearchChange = useCallback(
+    (e) => {
+      const val = e.target.value;
+      setSearchValue(val);
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+      searchTimerRef.current = setTimeout(() => {
+        onSearch?.(val);
+      }, SEARCH_DEBOUNCE_MS);
+    },
+    [onSearch],
+  );
+
+  const handleSortChange = useCallback(
+    (value) => {
+      setSortValue(value);
+      onSortChange?.(value);
+    },
+    [onSortChange],
+  );
+
   const clearAll = useCallback(() => {
     setSelectedValues({});
-    if (onClear) {
-      onClear();
+    setSortValue(null);
+    setSearchValue("");
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
     }
-    if (onApply) {
-      onApply({});
-    }
-  }, [onApply, onClear]);
+    onSearch?.("");
+    onSortChange?.(null);
+    onClear?.();
+    onApply?.({});
+  }, [onApply, onClear, onSearch, onSortChange]);
 
   const anySelected = useMemo(() => {
-    return Object.values(selectedValues).some((values) => values?.length > 0);
-  }, [selectedValues]);
+    return (
+      Object.values(selectedValues).some((values) => values?.length > 0) ||
+      !!searchValue ||
+      !!sortValue
+    );
+  }, [selectedValues, searchValue, sortValue]);
 
   // Collect all chips from all filter types
   const allChips = useMemo(() => {
@@ -175,17 +315,29 @@ const Filters = React.forwardRef(function Filters(
     return chips;
   }, [selectedValues, getChipLabel]);
 
+  const showSearch =
+    searchPlaceholderLabel !== undefined && searchPlaceholderLabel !== null;
+  const showSort = sortByLabel && sortOptions.length > 0;
+
   return (
     <Box ref={ref} display="flex" flexDirection="column" gap={1} sx={sx}>
-      {/* Row 1: Filter By Label */}
-      {filterByLabel && (
-        <Typography variant="subtitle1" fontWeight={700}>
-          {filterByLabel}
-        </Typography>
-      )}
-
-      {/* Row 2: Dropdown buttons */}
-      <Stack direction="row" spacing={2} flexWrap="wrap" useFlexGap>
+      {/* Row 1: Filter By Label + Filter dropdowns + Search + Sort By */}
+      <Stack
+        direction="row"
+        alignItems="center"
+        flexWrap="wrap"
+        useFlexGap
+        gap={2}
+      >
+        {filterByLabel && (
+          <Typography
+            variant="subtitle1"
+            fontWeight={700}
+            sx={{ flexShrink: 0 }}
+          >
+            {filterByLabel}
+          </Typography>
+        )}
         {processedFilters.map((filter) => (
           <FilterDropdown
             key={filter.type}
@@ -198,15 +350,37 @@ const Filters = React.forwardRef(function Filters(
             startIcon={
               <SvgIcon
                 component={filter.icon}
-                sx={{
-                  fill: "none",
-                  fontSize: "16px",
-                }}
+                sx={{ fill: "none", fontSize: "16px" }}
               />
             }
             size="small"
           />
         ))}
+        {showSearch && (
+          <InputBase
+            value={searchValue}
+            onChange={handleSearchChange}
+            placeholder={searchPlaceholderLabel || "Search..."}
+            sx={{
+              flex: 1,
+              minWidth: 180,
+              border: "1px solid #C9CACB",
+              borderRadius: "10px",
+              px: 1.5,
+              py: 0.5,
+              fontSize: "14px",
+              backgroundColor: "#fff",
+            }}
+          />
+        )}
+        {showSort && (
+          <SortDropdown
+            label={sortByLabel}
+            options={sortOptions}
+            value={sortValue}
+            onChange={handleSortChange}
+          />
+        )}
       </Stack>
 
       {/* Row 3: Chips + Actions */}

--- a/apps/trustlab/src/components/Filters/Filters.snap.js
+++ b/apps/trustlab/src/components/Filters/Filters.snap.js
@@ -5,14 +5,14 @@ exports[`ReportFilters renders unchanged 1`] = `
   <div
     class="MuiBox-root css-1821gv5"
   >
+    <h6
+      class="MuiTypography-root MuiTypography-subtitle1 css-1dte1p5-MuiTypography-root"
+    >
+      Filter By
+    </h6>
     <div
       class="MuiStack-root css-1u7tqyj-MuiStack-root"
     >
-      <h6
-        class="MuiTypography-root MuiTypography-subtitle1 css-14jb5t3-MuiTypography-root"
-      >
-        Filter By
-      </h6>
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-wl7jr6-MuiButtonBase-root-MuiButton-root"
         tabindex="0"

--- a/apps/trustlab/src/components/Filters/Filters.snap.js
+++ b/apps/trustlab/src/components/Filters/Filters.snap.js
@@ -5,14 +5,14 @@ exports[`ReportFilters renders unchanged 1`] = `
   <div
     class="MuiBox-root css-1821gv5"
   >
-    <h6
-      class="MuiTypography-root MuiTypography-subtitle1 css-1dte1p5-MuiTypography-root"
-    >
-      Filter By
-    </h6>
     <div
-      class="MuiStack-root css-p81m6m-MuiStack-root"
+      class="MuiStack-root css-1u7tqyj-MuiStack-root"
     >
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle1 css-14jb5t3-MuiTypography-root"
+      >
+        Filter By
+      </h6>
       <button
         class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-wl7jr6-MuiButtonBase-root-MuiButton-root"
         tabindex="0"

--- a/apps/trustlab/src/components/OpportunityList/OpportunityList.js
+++ b/apps/trustlab/src/components/OpportunityList/OpportunityList.js
@@ -16,6 +16,8 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
     cardActionLabel,
     hasPagination,
     hasFilters,
+    hasSearch,
+    hasSortBy,
     pagination: p = { page: 1, count: 1 },
     itemsType,
     itemsPerPage,
@@ -25,6 +27,9 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
     filterByLabel,
     applyFiltersLabel,
     clearFiltersLabel,
+    searchPlaceholderLabel,
+    sortByLabel,
+    sortOptions,
     title,
     description,
     ...other
@@ -94,7 +99,7 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
     params,
     initialItems,
     p?.count,
-    !hasFilters && !hasPagination,
+    !hasFilters && !hasPagination && !hasSearch && !hasSortBy,
     apiEndpoint,
   );
 
@@ -121,15 +126,20 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
   };
 
   function handleApplyFilters(filterParams) {
-    const newParams = {
+    setParams((prev) => ({
       type: itemsType,
       limit: itemsPerPage,
       ...filterParams,
-    };
-    setParams(newParams);
+      ...(prev.sort ? { sort: prev.sort } : {}),
+      ...(prev.search ? { search: prev.search } : {}),
+    }));
     setPage(1);
 
-    const searchParams = new URLSearchParams();
+    const searchParams = new URLSearchParams(window.location.search);
+    // clear existing filter params before setting new ones
+    ["year", "month", "location", "opportunity"].forEach((k) =>
+      searchParams.delete(k),
+    );
     Object.entries(filterParams).forEach(([key, value]) => {
       if (Array.isArray(value) && value.length > 0) {
         searchParams.set(key, value.join(","));
@@ -137,6 +147,63 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
         searchParams.set(key, value);
       }
     });
+    searchParams.delete("page");
+
+    const queryString = searchParams.toString();
+    let urlPath = window.location.pathname;
+    if (queryString) {
+      urlPath = `${urlPath}?${queryString}`;
+    }
+    router.push(urlPath, undefined, { shallow: true, scroll: false });
+  }
+
+  function handleSortChange(sortValue) {
+    setParams((prev) => {
+      const next = { ...prev };
+      if (sortValue) {
+        next.sort = sortValue;
+      } else {
+        delete next.sort;
+      }
+      return next;
+    });
+    setPage(1);
+
+    const searchParams = new URLSearchParams(window.location.search);
+    if (sortValue) {
+      searchParams.set("sort", sortValue);
+    } else {
+      searchParams.delete("sort");
+    }
+    searchParams.delete("page");
+
+    const queryString = searchParams.toString();
+    let urlPath = window.location.pathname;
+    if (queryString) {
+      urlPath = `${urlPath}?${queryString}`;
+    }
+    router.push(urlPath, undefined, { shallow: true, scroll: false });
+  }
+
+  function handleSearch(searchTerm) {
+    setParams((prev) => {
+      const next = { ...prev };
+      if (searchTerm) {
+        next.search = searchTerm;
+      } else {
+        delete next.search;
+      }
+      return next;
+    });
+    setPage(1);
+
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchTerm) {
+      searchParams.set("search", searchTerm);
+    } else {
+      searchParams.delete("search");
+    }
+    searchParams.delete("page");
 
     const queryString = searchParams.toString();
     let urlPath = window.location.pathname;
@@ -180,16 +247,22 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
         ) : null}
       </Box>
 
-      {hasFilters ? (
+      {hasFilters || hasSearch || hasSortBy ? (
         <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
           <Filters
             {...other}
             onApply={(filterParams) => handleApplyFilters(filterParams)}
             filters={filters}
             filterByLabel={filterByLabel}
-            hasFilters={hasFilters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}
+            onSearch={hasSearch ? handleSearch : undefined}
+            searchPlaceholderLabel={
+              hasSearch ? searchPlaceholderLabel : undefined
+            }
+            onSortChange={hasSortBy ? handleSortChange : undefined}
+            sortByLabel={hasSortBy ? sortByLabel : undefined}
+            sortOptions={hasSortBy ? sortOptions : undefined}
           />
         </Section>
       ) : null}

--- a/apps/trustlab/src/components/OpportunityList/OpportunityList.js
+++ b/apps/trustlab/src/components/OpportunityList/OpportunityList.js
@@ -125,7 +125,7 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
     }
   };
 
-  function handleApplyFilters(filterParams) {
+  const handleApplyFilters = (filterParams) => {
     setParams((prev) => ({
       type: itemsType,
       limit: itemsPerPage,
@@ -155,7 +155,16 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
       urlPath = `${urlPath}?${queryString}`;
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
-  }
+  };
+
+  const handleClearAll = () => {
+    setParams({ type: itemsType, limit: itemsPerPage });
+    setPage(1);
+    router.push(window.location.pathname, undefined, {
+      shallow: true,
+      scroll: false,
+    });
+  };
 
   function handleSortChange(sortValue) {
     setParams((prev) => {
@@ -250,12 +259,12 @@ const OpportunityList = forwardRef(function OpportunityList(props, ref) {
       {hasFilters || hasSearch || hasSortBy ? (
         <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
           <Filters
-            {...other}
-            onApply={(filterParams) => handleApplyFilters(filterParams)}
-            filters={filters}
             filterByLabel={filterByLabel}
+            filters={filters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}
+            onApply={handleApplyFilters}
+            onClearAll={handleClearAll}
             onSearch={hasSearch ? handleSearch : undefined}
             searchPlaceholderLabel={
               hasSearch ? searchPlaceholderLabel : undefined

--- a/apps/trustlab/src/components/OpportunityList/useOpportunities.js
+++ b/apps/trustlab/src/components/OpportunityList/useOpportunities.js
@@ -28,6 +28,9 @@ function useOpportunities(
   if (params?.search) {
     searchParams.set("search", params.search);
   }
+  if (params?.sort) {
+    searchParams.set("sort", params.sort);
+  }
   if (params?.opportunity) {
     searchParams.set("opportunity", params.opportunity);
   }

--- a/apps/trustlab/src/components/ReportsList/ReportsList.js
+++ b/apps/trustlab/src/components/ReportsList/ReportsList.js
@@ -20,6 +20,8 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     cardActionLabel,
     hasPagination,
     hasFilters,
+    hasSearch,
+    hasSortBy,
     pagination: p = { page: 1, count: 1 },
     reportsType,
     reportsPerPage,
@@ -37,6 +39,7 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
   const router = useRouter();
   const { query } = router;
   const { page: initialPage } = query;
+
   useEffect(() => {
     if (initialPage) {
       const parsed = parseInt(initialPage, 10);
@@ -76,6 +79,7 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       });
     }
   };
+
   function handleApplyFilters(filterParams) {
     // filter keys are singular (year/month/report); API expects plural
     const keyMap = { year: "years", month: "months", report: "reports" };
@@ -83,10 +87,19 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       Object.entries(filterParams).map(([k, v]) => [keyMap[k] ?? k, v]),
     );
 
-    setParams({ reportsType, limit: reportsPerPage, ...mappedParams });
+    setParams((prev) => ({
+      reportsType,
+      limit: reportsPerPage,
+      ...mappedParams,
+      // preserve sort and search across filter changes
+      ...(prev.sort ? { sort: prev.sort } : {}),
+      ...(prev.search ? { search: prev.search } : {}),
+    }));
     setPage(1);
 
-    const searchParams = new URLSearchParams();
+    const searchParams = new URLSearchParams(window.location.search);
+    // clear existing filter params before setting new ones
+    ["years", "months", "reports"].forEach((k) => searchParams.delete(k));
     Object.entries(mappedParams).forEach(([key, value]) => {
       if (Array.isArray(value) && value.length > 0) {
         searchParams.set(key, value.join(","));
@@ -94,6 +107,63 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
         searchParams.set(key, value);
       }
     });
+    searchParams.delete("page");
+
+    const queryString = searchParams.toString();
+    let urlPath = window.location.pathname;
+    if (queryString) {
+      urlPath = `${urlPath}?${queryString}`;
+    }
+    router.push(urlPath, undefined, { shallow: true, scroll: false });
+  }
+
+  function handleSortChange(sortValue) {
+    setParams((prev) => {
+      const next = { ...prev };
+      if (sortValue) {
+        next.sort = sortValue;
+      } else {
+        delete next.sort;
+      }
+      return next;
+    });
+    setPage(1);
+
+    const searchParams = new URLSearchParams(window.location.search);
+    if (sortValue) {
+      searchParams.set("sort", sortValue);
+    } else {
+      searchParams.delete("sort");
+    }
+    searchParams.delete("page");
+
+    const queryString = searchParams.toString();
+    let urlPath = window.location.pathname;
+    if (queryString) {
+      urlPath = `${urlPath}?${queryString}`;
+    }
+    router.push(urlPath, undefined, { shallow: true, scroll: false });
+  }
+
+  function handleSearch(searchTerm) {
+    setParams((prev) => {
+      const next = { ...prev };
+      if (searchTerm) {
+        next.search = searchTerm;
+      } else {
+        delete next.search;
+      }
+      return next;
+    });
+    setPage(1);
+
+    const searchParams = new URLSearchParams(window.location.search);
+    if (searchTerm) {
+      searchParams.set("search", searchTerm);
+    } else {
+      searchParams.delete("search");
+    }
+    searchParams.delete("page");
 
     const queryString = searchParams.toString();
     let urlPath = window.location.pathname;
@@ -108,8 +178,8 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     if (!router.isReady) {
       return;
     }
-    const { years, months, reports: reportsFilter } = query;
-    if (!years && !months && !reportsFilter) {
+    const { years, months, reports: reportsFilter, sort, search } = query;
+    if (!years && !months && !reportsFilter && !sort && !search) {
       return;
     }
 
@@ -126,18 +196,28 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     if (reportsFilter) {
       newParams.reports = parseParam(reportsFilter);
     }
+    if (sort) {
+      newParams.sort = sort;
+    }
+    if (search) {
+      newParams.search = search;
+    }
 
     setParams(newParams);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.isReady]);
 
+  const showFiltersBar = hasFilters || hasSearch || hasSortBy;
+
   return (
     <Box ref={listRef}>
-      {hasFilters ? (
+      {showFiltersBar ? (
         <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
           <Filters
             {...other}
             onApply={(filterParams) => handleApplyFilters(filterParams)}
+            onSortChange={hasSortBy ? handleSortChange : undefined}
+            onSearch={hasSearch ? handleSearch : undefined}
           />
         </Section>
       ) : null}

--- a/apps/trustlab/src/components/ReportsList/ReportsList.js
+++ b/apps/trustlab/src/components/ReportsList/ReportsList.js
@@ -27,6 +27,14 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     reportsPerPage,
     notFoundTitleLabel,
     notFoundSubtitleLabel,
+    // filter bar props — destructured so they don't leak into <Grid>
+    filterByLabel,
+    filters,
+    clearFiltersLabel,
+    applyFiltersLabel,
+    searchPlaceholderLabel,
+    sortByLabel,
+    sortOptions,
     ...other
   } = props;
 
@@ -80,7 +88,7 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     }
   };
 
-  function handleApplyFilters(filterParams) {
+  const handleApplyFilters = (filterParams) => {
     // filter keys are singular (year/month/report); API expects plural
     const keyMap = { year: "years", month: "months", report: "reports" };
     const mappedParams = Object.fromEntries(
@@ -115,9 +123,9 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       urlPath = `${urlPath}?${queryString}`;
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
-  }
+  };
 
-  function handleSortChange(sortValue) {
+  const handleSortChange = (sortValue) => {
     setParams((prev) => {
       const next = { ...prev };
       if (sortValue) {
@@ -143,9 +151,18 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       urlPath = `${urlPath}?${queryString}`;
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
-  }
+  };
 
-  function handleSearch(searchTerm) {
+  const handleClearAll = () => {
+    setParams({ reportsType, limit: reportsPerPage });
+    setPage(1);
+    router.push(window.location.pathname, undefined, {
+      shallow: true,
+      scroll: false,
+    });
+  };
+
+  const handleSearch = (searchTerm) => {
     setParams((prev) => {
       const next = { ...prev };
       if (searchTerm) {
@@ -171,7 +188,7 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       urlPath = `${urlPath}?${queryString}`;
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
-  }
+  };
 
   // Initialize params from URL on mount (e.g. bookmarked filtered URL)
   useEffect(() => {
@@ -214,10 +231,19 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
       {showFiltersBar ? (
         <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
           <Filters
-            {...other}
-            onApply={(filterParams) => handleApplyFilters(filterParams)}
+            filterByLabel={filterByLabel}
+            filters={filters}
+            clearFiltersLabel={clearFiltersLabel}
+            applyFiltersLabel={applyFiltersLabel}
+            onApply={handleApplyFilters}
+            onClearAll={handleClearAll}
             onSortChange={hasSortBy ? handleSortChange : undefined}
+            sortByLabel={hasSortBy ? sortByLabel : undefined}
+            sortOptions={hasSortBy ? sortOptions : undefined}
             onSearch={hasSearch ? handleSearch : undefined}
+            searchPlaceholderLabel={
+              hasSearch ? searchPlaceholderLabel : undefined
+            }
           />
         </Section>
       ) : null}

--- a/apps/trustlab/src/components/ReportsList/useReports.js
+++ b/apps/trustlab/src/components/ReportsList/useReports.js
@@ -12,6 +12,12 @@ function useReports(page, params, initialReports, initialCount, skip) {
   if (params?.reportsType) {
     searchParams.set("reportsType", params.reportsType);
   }
+  if (params?.sort) {
+    searchParams.set("sort", params.sort);
+  }
+  if (params?.search) {
+    searchParams.set("search", params.search);
+  }
 
   ["years", "months", "reports"].forEach((key) => {
     if (params?.[key]) {

--- a/apps/trustlab/src/lib/data/getOpportunities.js
+++ b/apps/trustlab/src/lib/data/getOpportunities.js
@@ -22,12 +22,17 @@ async function getOpportunities(api, options = {}) {
     year,
     opportunity: id,
     month,
+    search,
   } = options;
 
   const where = {};
 
   if (type && type !== "all") {
     where.type = { equals: type };
+  }
+
+  if (search) {
+    where.title = { like: search };
   }
 
   if (id) {

--- a/apps/trustlab/src/pages/api/v1/opportunities.page.js
+++ b/apps/trustlab/src/pages/api/v1/opportunities.page.js
@@ -15,6 +15,8 @@ export default async function handler(req, res) {
       month,
       location,
       opportunity,
+      search,
+      sort,
     } = req.query;
 
     const limit = parseInt(req.query?.limit, 10) || 12;
@@ -27,6 +29,8 @@ export default async function handler(req, res) {
       month,
       location,
       opportunity,
+      ...(search ? { search } : {}),
+      ...(sort ? { sort } : {}),
     };
 
     const result = await getOpportunities(api, options);

--- a/apps/trustlab/src/pages/api/v1/opportunities.page.js
+++ b/apps/trustlab/src/pages/api/v1/opportunities.page.js
@@ -20,6 +20,19 @@ export default async function handler(req, res) {
     } = req.query;
 
     const limit = parseInt(req.query?.limit, 10) || 12;
+    const ALLOWED_SORT = [
+      "-date",
+      "date",
+      "-title",
+      "title",
+      "-createdAt",
+      "createdAt",
+      "-updatedAt",
+      "updatedAt",
+    ];
+    const validatedSort =
+      sort && ALLOWED_SORT.includes(sort) ? sort : undefined;
+
     const options = {
       page: parseInt(page, 10),
       limit,
@@ -30,7 +43,7 @@ export default async function handler(req, res) {
       location,
       opportunity,
       ...(search ? { search } : {}),
-      ...(sort ? { sort } : {}),
+      ...(validatedSort ? { sort: validatedSort } : {}),
     };
 
     const result = await getOpportunities(api, options);

--- a/apps/trustlab/src/pages/api/v1/reports/index.page.js
+++ b/apps/trustlab/src/pages/api/v1/reports/index.page.js
@@ -111,10 +111,23 @@ export default async function handler(req, res) {
     const where = andConditions.length > 0 ? { and: andConditions } : {};
 
     try {
+      const ALLOWED_SORT = [
+        "-date",
+        "date",
+        "-title",
+        "title",
+        "-createdAt",
+        "createdAt",
+        "-updatedAt",
+        "updatedAt",
+      ];
+      const validatedSort =
+        sort && ALLOWED_SORT.includes(sort) ? sort : "-createdAt";
+
       const result = await getReports(api, {
         limit,
         page: page || 1,
-        sort: sort || "-createdAt",
+        sort: validatedSort,
         where,
       });
       return res.status(200).json(result);

--- a/apps/trustlab/src/pages/api/v1/reports/index.page.js
+++ b/apps/trustlab/src/pages/api/v1/reports/index.page.js
@@ -12,6 +12,7 @@ export default async function handler(req, res) {
       months,
       reports,
       reportsType,
+      search,
       limit = 12,
     } = req.query;
 
@@ -45,6 +46,11 @@ export default async function handler(req, res) {
     const andConditions = [];
     if (reportsType) {
       andConditions.push({ reportType: { equals: reportsType } });
+    }
+
+    // Title search
+    if (search) {
+      andConditions.push({ title: { like: search } });
     }
 
     // Reports (slug) filter

--- a/apps/trustlab/src/payload/blocks/OpportunityList.js
+++ b/apps/trustlab/src/payload/blocks/OpportunityList.js
@@ -95,6 +95,57 @@ const OpportunityList = {
       },
     },
     {
+      name: "hasSearch",
+      type: "checkbox",
+      label: { en: "Enable Search" },
+    },
+    {
+      name: "searchPlaceholderLabel",
+      type: "text",
+      label: { en: "Search Placeholder Label" },
+      localized: true,
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSearch),
+      },
+    },
+    {
+      name: "hasSortBy",
+      type: "checkbox",
+      label: { en: "Enable Sort By" },
+    },
+    {
+      name: "sortByLabel",
+      type: "text",
+      label: { en: "Sort By Label" },
+      localized: true,
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSortBy),
+      },
+    },
+    {
+      name: "sortOptions",
+      type: "array",
+      label: { en: "Sort Options" },
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSortBy),
+      },
+      fields: [
+        {
+          name: "label",
+          type: "text",
+          label: { en: "Option Label" },
+          localized: true,
+          required: true,
+        },
+        {
+          name: "value",
+          type: "text",
+          label: { en: "Sort Value (e.g. -date, date, -title)" },
+          required: true,
+        },
+      ],
+    },
+    {
       name: "hasPagination",
       type: "checkbox",
       label: { en: "Enable Pagination" },

--- a/apps/trustlab/src/payload/blocks/OpportunityList.js
+++ b/apps/trustlab/src/payload/blocks/OpportunityList.js
@@ -91,7 +91,12 @@ const OpportunityList = {
       type: "text",
       localized: true,
       admin: {
-        condition: (_, siblingData) => Boolean(siblingData?.hasFilters),
+        condition: (_, siblingData) =>
+          Boolean(
+            siblingData?.hasFilters ||
+            siblingData?.hasSearch ||
+            siblingData?.hasSortBy,
+          ),
       },
     },
     {

--- a/apps/trustlab/src/payload/blocks/ReportsList.js
+++ b/apps/trustlab/src/payload/blocks/ReportsList.js
@@ -85,6 +85,57 @@ const ReportsList = {
       },
     },
     {
+      name: "hasSearch",
+      type: "checkbox",
+      label: { en: "Enable Search" },
+    },
+    {
+      name: "searchPlaceholderLabel",
+      type: "text",
+      label: { en: "Search Placeholder Label" },
+      localized: true,
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSearch),
+      },
+    },
+    {
+      name: "hasSortBy",
+      type: "checkbox",
+      label: { en: "Enable Sort By" },
+    },
+    {
+      name: "sortByLabel",
+      type: "text",
+      label: { en: "Sort By Label" },
+      localized: true,
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSortBy),
+      },
+    },
+    {
+      name: "sortOptions",
+      type: "array",
+      label: { en: "Sort Options" },
+      admin: {
+        condition: (_, siblingData) => Boolean(siblingData?.hasSortBy),
+      },
+      fields: [
+        {
+          name: "label",
+          type: "text",
+          label: { en: "Option Label" },
+          localized: true,
+          required: true,
+        },
+        {
+          name: "value",
+          type: "text",
+          label: { en: "Sort Value (e.g. -date, date, -title)" },
+          required: true,
+        },
+      ],
+    },
+    {
       name: "cardActionLabel",
       type: "text",
       localized: true,

--- a/apps/trustlab/src/payload/blocks/ReportsList.js
+++ b/apps/trustlab/src/payload/blocks/ReportsList.js
@@ -146,7 +146,12 @@ const ReportsList = {
       type: "text",
       localized: true,
       admin: {
-        condition: (_, siblingData) => Boolean(siblingData?.hasFilters),
+        condition: (_, siblingData) =>
+          Boolean(
+            siblingData?.hasFilters ||
+            siblingData?.hasSearch ||
+            siblingData?.hasSortBy,
+          ),
       },
     },
     {


### PR DESCRIPTION
## Description
- **Search**: New CMS-configurable search input that filters by title (debounced, 400 ms). Enabled via `hasSearch` checkbox; placeholder text is localizable.                                                         
   - **Sort By**: New CMS-configurable single-select sort dropdown. Enabled via `hasSortBy` checkbox; editors define any number of sort options (label + Payload sort value e.g. `-date`, `title`).                      
   - **Unified filter bar**: All controls — filter label, filter dropdowns, search input, and sort dropdown — now live in a single flex row that wraps on small screens.                                                 
   - **URL sync**: Search and sort values are synced to the URL query string (`?search=`, `?sort=`) alongside existing filter params, so filtered/sorted views are bookmarkable.
   - Both `ReportsList` and `OpportunityList` blocks receive the same set of new fields and component wiring.

   ## Changed files

   | File | What changed |
   |------|-------------|
   | `payload/blocks/ReportsList.js` | Added `hasSearch`, `searchPlaceholderLabel`, `hasSortBy`, `sortByLabel`, `sortOptions` CMS fields |
   | `payload/blocks/OpportunityList.js` | Same new CMS fields as above |
   | `components/Filters/Filters.js` | Added `SortDropdown` sub-component; `searchPlaceholderLabel`/`onSearch` props (debounced input); `sortByLabel`/`sortOptions`/`onSortChange` props; single-row layout for all
   controls; `clearAll` resets search + sort |
   | `components/ReportsList/ReportsList.js` | Destructures new props; `handleSearch` + `handleSortChange` handlers with URL sync; filter bar shown when any of `hasFilters`, `hasSearch`, `hasSortBy` is set |
   | `components/ReportsList/useReports.js` | Forwards `sort` and `search` params to the API |
   | `pages/api/v1/reports/index.page.js` | Reads `search` query param; adds `{ title: { like: search } }` to Payload where clause |
   | `components/OpportunityList/OpportunityList.js` | Same handler + prop changes as ReportsList |
   | `components/OpportunityList/useOpportunities.js` | Forwards `sort` param to the API (search was already wired) |
   | `pages/api/v1/opportunities.page.js` | Passes `search` and `sort` through to `getOpportunities` |
   | `lib/data/getOpportunities.js` | Adds `where.title = { like: search }` when `search` is present |

   ## Test plan

   - [x] Enable `hasSortBy` on a ReportsList block in the CMS, add options (`-date` / `date`), verify the sort dropdown appears in the filter bar and changes result order
   - [x] Enable `hasSearch`, type a partial title, verify results filter after the debounce and the URL updates with `?search=`
   - [x] Reload the page with `?search=foo&sort=-date` in the URL and verify state is restored
   - [x] Clear filters — confirm search input clears, sort resets, and chips disappear
   - [x] Repeat all of the above for an OpportunityList block
   - [x] Verify blocks with none of the new flags enabled are unaffected

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Screenshots
<img width="1167" height="640" alt="image" src="https://github.com/user-attachments/assets/8e481ce6-885a-42b6-b3f5-0b6fa50862df" />
<img width="543" height="907" alt="image" src="https://github.com/user-attachments/assets/c35c4d2b-8aa4-47eb-9a50-70269b121703" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
