### PR TITLE
Run bake workflows on native target architecture

### DIFF
--- a/.github/workflows/bake-and-push.yml
+++ b/.github/workflows/bake-and-push.yml
@@ -17,14 +17,14 @@ permissions:
 on:
   workflow_call:
     inputs:
-      target_os:
-        required: true
-        type: string
-        description: "Target OS (e.g. ubuntu-24.04 or ubuntu-24.04-arm) of the image"
       target:
         required: true
         type: string
         description: "Bake target name (e.g. techlabblog)"
+      target_os:
+        required: true
+        type: string
+        description: "JSON string. Target OS (e.g. ubuntu-24.04 or ubuntu-24.04-arm) of the image"
       tag:
         required: true
         type: string
@@ -68,10 +68,9 @@ on:
 
 jobs:
   bake:
-    runs-on: ${{ inputs.target_os }}
+    runs-on: ${{ fromJSON(inputs.target_os) }}
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/bake-and-push.yml
+++ b/.github/workflows/bake-and-push.yml
@@ -17,6 +17,11 @@ permissions:
 on:
   workflow_call:
     inputs:
+      arch:
+        required: true
+        type: string
+        description: "Target architecture (e.g. amd64 or arm64) of the image"
+        default: "amd64"
       target:
         required: true
         type: string
@@ -35,11 +40,6 @@ on:
           Use this in CI to avoid rebuilding base images on every app push.
           Omit (or leave empty) to build base images inline — useful when
           testing base image changes locally via act or in build-base-images.yml.
-      platforms:
-        required: false
-        type: string
-        default: "linux/amd64,linux/arm64"
-        description: "Target platforms (comma-separated). Override to build for a single platform."
       set:
         required: false
         type: string
@@ -69,7 +69,7 @@ on:
 
 jobs:
   bake:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
     permissions:
       contents: read
 
@@ -81,8 +81,6 @@ jobs:
       - name: Build metadata
         id: meta
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
-
-      - uses: docker/setup-qemu-action@v3
 
       - uses: docker/setup-buildx-action@v3
 
@@ -110,5 +108,4 @@ jobs:
           set: |
             *.cache-from=type=gha,scope=${{ inputs.target }}
             *.cache-to=type=gha,mode=max,scope=${{ inputs.target }}
-            *.platform=${{ inputs.platforms }}
             ${{ inputs.set }}

--- a/.github/workflows/bake-and-push.yml
+++ b/.github/workflows/bake-and-push.yml
@@ -24,7 +24,9 @@ on:
       target_os:
         required: true
         type: string
-        description: "JSON string. Target OS (e.g. ubuntu-24.04 or ubuntu-24.04-arm) of the image"
+        description: >
+          JSON string. Target OS (e.g. ubuntu-24.04-arm or
+          ['ubuntu-24.04-arm', 'ubuntu-24.04']) of the image
       tag:
         required: true
         type: string
@@ -72,7 +74,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -80,15 +82,15 @@ jobs:
         id: meta
         run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
-        uses: docker/bake-action@v6
+        uses: docker/bake-action@v7
         env:
           TAG: ${{ inputs.tag }}
           BASE_TAG: ${{ inputs.base_tag }}

--- a/.github/workflows/bake-and-push.yml
+++ b/.github/workflows/bake-and-push.yml
@@ -17,11 +17,10 @@ permissions:
 on:
   workflow_call:
     inputs:
-      arch:
+      os:
         required: true
         type: string
-        description: "Target architecture (e.g. amd64 or arm64) of the image"
-        default: "amd64"
+        description: "Target OS (e.g. ubuntu-24.04 or ubuntu-24.04-arm) of the image"
       target:
         required: true
         type: string
@@ -69,7 +68,7 @@ on:
 
 jobs:
   bake:
-    runs-on: ${{ inputs.architecture == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-24.04' }}
+    runs-on: ${{ inputs.os }}
     permissions:
       contents: read
 

--- a/.github/workflows/bake-and-push.yml
+++ b/.github/workflows/bake-and-push.yml
@@ -17,7 +17,7 @@ permissions:
 on:
   workflow_call:
     inputs:
-      os:
+      target_os:
         required: true
         type: string
         description: "Target OS (e.g. ubuntu-24.04 or ubuntu-24.04-arm) of the image"
@@ -68,7 +68,7 @@ on:
 
 jobs:
   bake:
-    runs-on: ${{ inputs.os }}
+    runs-on: ${{ inputs.target_os }}
     permissions:
       contents: read
 

--- a/.github/workflows/push-to-dokku.yml
+++ b/.github/workflows/push-to-dokku.yml
@@ -21,7 +21,7 @@ jobs:
     permissions: {}
 
     steps:
-      - name: Push
+      - name: Deploy
         uses: dokku/github-action@v1.7.0
         with:
           git_remote_url: ${{ inputs.git_remote_url }}

--- a/.github/workflows/techlabblog.yml
+++ b/.github/workflows/techlabblog.yml
@@ -83,8 +83,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/bake-and-push.yml
     with:
-      os: ${{ matrix.target_os }}
       target: techlabblog
+      target_os: ${{ matrix.target_os }}
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/techlabblog.yml
+++ b/.github/workflows/techlabblog.yml
@@ -39,19 +39,19 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       # EndBug/version-check requires Node.js — it ships as a JS action.
       # https://github.com/EndBug/version-check#github-workflow
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Check if version is bumped
         id: check
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@v3
         with:
           # Search every commit's diff, not just the commit message. This catches
           # version bumps that aren't mentioned in the commit message.

--- a/.github/workflows/techlabblog.yml
+++ b/.github/workflows/techlabblog.yml
@@ -31,7 +31,8 @@ jobs:
     strategy:
       matrix:
         node-version: [24]
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
+        target_os: [ubuntu-24.04-arm]
     permissions:
       contents: read
     outputs:
@@ -82,8 +83,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/bake-and-push.yml
     with:
+      os: ${{ matrix.target_os }}
       target: techlabblog
-      arch: arm64
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/techlabblog.yml
+++ b/.github/workflows/techlabblog.yml
@@ -83,6 +83,7 @@ jobs:
     uses: ./.github/workflows/bake-and-push.yml
     with:
       target: techlabblog
+      arch: arm64
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/techlabblog.yml
+++ b/.github/workflows/techlabblog.yml
@@ -84,7 +84,7 @@ jobs:
     uses: ./.github/workflows/bake-and-push.yml
     with:
       target: techlabblog
-      target_os: ${{ matrix.target_os }}
+      target_os: "['ubuntu-24.04-arm']"
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -58,10 +58,9 @@ jobs:
     uses: ./.github/workflows/bake-and-push.yml
     with:
       target: trustlab
+      arch: arm64
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
-      # Both DEV and PROD are running on arm64 machines.
-      platforms: linux/arm64
       set: |
         ${{ needs.version-check.outputs.changed == 'true' && format('trustlab.tags=codeforafrica/trustlab:{0}', github.sha) || '' }}
         ${{ needs.version-check.outputs.changed == 'true' && format('trustlab.tags=codeforafrica/trustlab:{0}', needs.version-check.outputs.version) || '' }}

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -29,7 +29,6 @@ jobs:
       matrix:
         node-version: [24]
         os: [ubuntu-24.04]
-        target_os: [ubuntu-24.04-arm]
     permissions:
       contents: read
     outputs:
@@ -60,7 +59,7 @@ jobs:
     uses: ./.github/workflows/bake-and-push.yml
     with:
       target: trustlab
-      target_os: ${{ matrix.target_os }}
+      target_os: "['ubuntu-24.04-arm']"
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       matrix:
         node-version: [24]
-        os: [ubuntu-latest]
+        os: [ubuntu-24.04]
+        target_os: [ubuntu-24.04-arm]
     permissions:
       contents: read
     outputs:
@@ -58,8 +59,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/bake-and-push.yml
     with:
+      os: ${{ matrix.target_os }}
       target: trustlab
-      arch: arm64
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -35,17 +35,17 @@ jobs:
       changed: ${{ steps.check.outputs.changed }}
       version: ${{ steps.check.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Check if version is bumped
         id: check
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@v3
         with:
           diff-search: true
           file-name: apps/trustlab/package.json

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/test-workflows-runs-on-arm64
     paths:
       - "apps/trustlab/**"
       - "docker/apps/trustlab/**"

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/test-workflows-runs-on-arm64
     paths:
       - "apps/trustlab/**"
       - "docker/apps/trustlab/**"

--- a/.github/workflows/trustlab.yml
+++ b/.github/workflows/trustlab.yml
@@ -59,8 +59,8 @@ jobs:
       contents: read
     uses: ./.github/workflows/bake-and-push.yml
     with:
-      os: ${{ matrix.target_os }}
       target: trustlab
+      target_os: ${{ matrix.target_os }}
       base_tag: ${{ vars.UI_BASE_TAG }}
       tag: ${{ github.sha }}
       set: |


### PR DESCRIPTION
## Description

This updates the reusable image build workflow to run on the target runner architecture instead of relying on emulation.

### Key changes:

  - add a `target_os` input to `.github/workflows/bake-and-push.yml`
  - run bake jobs on the provided runner OS/architecture
  - remove the old `platforms` override from the reusable bake workflow
  - update `techlabblog` and `trustlab` workflows to pass ARM runners explicitly
  - bump GitHub Action versions used by the affected workflows
  - rename the Dokku step from `Push` to `Deploy` for clarity
 
## Type of change

Please delete options that are not relevant.

- [x] Chore

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
