### PR TITLE
fix(trustlab): enforce role-based Payload content access

### DIFF
--- a/apps/trustlab/src/app/preview/route.ts
+++ b/apps/trustlab/src/app/preview/route.ts
@@ -6,7 +6,7 @@ import { redirect } from "next/navigation";
 import type { NextRequest } from "next/server";
 
 import configPromise from "@payload-config";
-import { canManageContent } from "@/trustlab/payload/access/abilities";
+import { isAuthor } from "@/trustlab/payload/access/abilities";
 
 export async function GET(req: NextRequest): Promise<Response> {
   const payload = await getPayload({ config: configPromise });
@@ -37,7 +37,7 @@ export async function GET(req: NextRequest): Promise<Response> {
       "Error verifying token for live preview",
     );
   }
-  if (!(authResult && canManageContent(authResult?.user))) {
+  if (!(authResult && isAuthor(authResult?.user))) {
     return new Response("You are not allowed to preview this page", {
       status: 403,
     });

--- a/apps/trustlab/src/lib/data/rest/index.js
+++ b/apps/trustlab/src/lib/data/rest/index.js
@@ -55,6 +55,8 @@ export const api = {
   findPage,
 };
 
+// pages/_error getInitialProps can run on the server or in the browser.
+// Keep this path on REST so it does not import Payload's server-only local API.
 export async function getErrorPageProps(context) {
   const slug = context?.params?.slugs?.[0] || "404";
   const props = await getProps(api, slug);

--- a/apps/trustlab/src/payload/access/abilities.js
+++ b/apps/trustlab/src/payload/access/abilities.js
@@ -41,7 +41,7 @@ export const hasAdminAccess = ({ req } = {}) => isAdmin(req?.user);
 
 // TODO(@kelvinkipruto): what happens on delete? cascade or not?
 export const canManageUser = (user) => {
-  if (!user) {
+  if (!isLoggedIn(user)) {
     return false;
   }
   // Admins can manage all users
@@ -49,6 +49,9 @@ export const canManageUser = (user) => {
     return true;
   }
   // All other users can manage their own accounts
+  if (!user.id) {
+    return false;
+  }
   const orQuery = [
     {
       id: {

--- a/apps/trustlab/src/payload/access/abilities.js
+++ b/apps/trustlab/src/payload/access/abilities.js
@@ -1,16 +1,31 @@
 import { checkRole } from "./checkRole";
-import { ROLE_ADMIN, ROLE_AUTHOR, ROLE_EDITOR } from "./roles";
+import { hasValidRole, ROLE_ADMIN, ROLE_AUTHOR, ROLE_EDITOR } from "./roles";
 
-export const canManageContent = (user) => {
-  if (!user) {
+export const isLoggedIn = (user) => hasValidRole(user);
+
+export const hasLoggedInAccess = ({ req } = {}) => isLoggedIn(req?.user);
+
+// Admins and editors can manage any content
+export const isEditor = (user) => checkRole([ROLE_ADMIN, ROLE_EDITOR], user);
+
+export const hasEditorAccess = ({ req } = {}) => isEditor(req?.user);
+
+export const isAuthor = (user) => {
+  // Any valid CMS user has at least author-level capability.
+  return isLoggedIn(user);
+};
+
+export const canAuthor = (user) => {
+  if (!isLoggedIn(user)) {
     return false;
   }
-  // Admin and editors can manage any content
-  if (checkRole([ROLE_ADMIN, ROLE_EDITOR], user)) {
+  if (isEditor(user)) {
     return true;
   }
-
-  // Everyone else can only manage their own content
+  if (!user.id) {
+    return false;
+  }
+  // Authors can manage own content only
   return {
     createdBy: {
       equals: user.id,
@@ -18,14 +33,14 @@ export const canManageContent = (user) => {
   };
 };
 
-export const canManagePages = (user) =>
-  checkRole([ROLE_ADMIN, ROLE_EDITOR], user);
+export const hasAuthorAccess = ({ req } = {}) => canAuthor(req?.user);
 
-export const canManageSiteSettings = ({ req: { user } }) =>
-  checkRole([ROLE_ADMIN], user);
+export const isAdmin = (user) => checkRole([ROLE_ADMIN], user);
+
+export const hasAdminAccess = ({ req } = {}) => isAdmin(req?.user);
 
 // TODO(@kelvinkipruto): what happens on delete? cascade or not?
-export const canManageUsers = (user) => {
+export const canManageUser = (user) => {
   if (!user) {
     return false;
   }
@@ -50,5 +65,8 @@ export const canManageUsers = (user) => {
   };
 };
 
-export const canCreateAccounts = (user) =>
-  checkRole([ROLE_ADMIN, ROLE_EDITOR], user);
+export const hasManageUserAccess = ({ req } = {}) => canManageUser(req?.user);
+
+export const hasCreateUserAccess = (args) => hasEditorAccess(args);
+
+export default undefined;

--- a/apps/trustlab/src/payload/access/index.js
+++ b/apps/trustlab/src/payload/access/index.js
@@ -1,2 +1,2 @@
+export * from "./abilities";
 export * from "./anyone";
-export * from "./loggedIn";

--- a/apps/trustlab/src/payload/access/index.test.js
+++ b/apps/trustlab/src/payload/access/index.test.js
@@ -121,9 +121,21 @@ describe("payload.access", () => {
       });
     });
 
-    it("denies requests from anonymous users", () => {
+    it("denies requests from invalid-role and anonymous users", () => {
+      expect(
+        hasManageUserAccess({ req: { user: { id: 1, role: "unknown" } } }),
+      ).toBe(false);
       expect(hasManageUserAccess({ req: {} })).toBe(false);
       expect(hasManageUserAccess(undefined)).toBe(false);
+    });
+
+    it("denies requests from non-admin users without a user id for ownership checks", () => {
+      expect(
+        hasManageUserAccess({ req: { user: { role: ROLE_AUTHOR } } }),
+      ).toBe(false);
+      expect(
+        hasManageUserAccess({ req: { user: { role: ROLE_EDITOR } } }),
+      ).toBe(false);
     });
   });
 

--- a/apps/trustlab/src/payload/access/index.test.js
+++ b/apps/trustlab/src/payload/access/index.test.js
@@ -1,0 +1,182 @@
+import {
+  canAuthor,
+  hasAdminAccess,
+  hasAuthorAccess,
+  hasCreateUserAccess,
+  hasManageUserAccess,
+  hasEditorAccess,
+  hasLoggedInAccess,
+  isAuthor,
+} from "./abilities";
+import { anyone } from "./anyone";
+import { ROLE_ADMIN, ROLE_AUTHOR, ROLE_EDITOR } from "./roles";
+
+describe("payload.access", () => {
+  describe("abilities.hasAdminAccess", () => {
+    it("allows requests from administrators", () => {
+      expect(hasAdminAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+    });
+
+    it("denies requests from authors, editors, and anonymous users", () => {
+      expect(hasAdminAccess({ req: { user: { role: ROLE_AUTHOR } } })).toBe(
+        false,
+      );
+      expect(hasAdminAccess({ req: { user: { role: ROLE_EDITOR } } })).toBe(
+        false,
+      );
+      expect(hasAdminAccess({ req: {} })).toBe(false);
+      expect(hasAdminAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.isAuthor", () => {
+    it("allows users with administrators, authors and editors roles", () => {
+      expect(isAuthor({ role: ROLE_ADMIN })).toBe(true);
+      expect(isAuthor({ role: ROLE_AUTHOR })).toBe(true);
+      expect(isAuthor({ role: ROLE_EDITOR })).toBe(true);
+    });
+
+    it("denies users without a valid role", () => {
+      expect(isAuthor({ role: "unknown" })).toBe(false);
+      expect(isAuthor(1)).toBe(false);
+      expect(isAuthor(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.canAuthor", () => {
+    it("allows administrators and editors to author any content", () => {
+      expect(canAuthor({ role: ROLE_ADMIN })).toBe(true);
+      expect(canAuthor({ role: ROLE_EDITOR })).toBe(true);
+    });
+
+    it("limits authors to their own content", () => {
+      expect(canAuthor({ id: 1, role: ROLE_AUTHOR })).toEqual({
+        createdBy: { equals: 1 },
+      });
+    });
+
+    it("denies authors without a user id for ownership checks", () => {
+      expect(canAuthor({ role: ROLE_AUTHOR })).toBe(false);
+    });
+
+    it("denies users without a valid role", () => {
+      expect(canAuthor({ role: "unknown" })).toBe(false);
+      expect(canAuthor(1)).toBe(false);
+      expect(canAuthor(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.hasAuthorAccess", () => {
+    it("allows requests from administrators, authors and editors", () => {
+      expect(hasAuthorAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+      expect(
+        hasAuthorAccess({ req: { user: { id: 1, role: ROLE_AUTHOR } } }),
+      ).toEqual({ createdBy: { equals: 1 } });
+      expect(hasAuthorAccess({ req: { user: { role: ROLE_EDITOR } } })).toBe(
+        true,
+      );
+    });
+
+    it("denies requests from anonymous users", () => {
+      expect(hasAuthorAccess({ req: {} })).toBe(false);
+      expect(hasAuthorAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.hasCreateUserAccess", () => {
+    it("allows requests from administrators and editors", () => {
+      expect(hasCreateUserAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+      expect(
+        hasCreateUserAccess({ req: { user: { role: ROLE_EDITOR } } }),
+      ).toBe(true);
+    });
+
+    it("denies requests from authors and anonymous users", () => {
+      expect(
+        hasCreateUserAccess({ req: { user: { role: ROLE_AUTHOR } } }),
+      ).toBe(false);
+      expect(hasCreateUserAccess({ req: {} })).toBe(false);
+      expect(hasCreateUserAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.hasManageUserAccess", () => {
+    it("allows requests from administrators, authors and editors", () => {
+      expect(hasManageUserAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+      expect(
+        hasManageUserAccess({ req: { user: { id: 1, role: ROLE_AUTHOR } } }),
+      ).toEqual({ or: [{ id: { equals: 1 } }] });
+      expect(
+        hasManageUserAccess({ req: { user: { id: 1, role: ROLE_EDITOR } } }),
+      ).toEqual({
+        or: [{ id: { equals: 1 } }, { role: { equals: ROLE_AUTHOR } }],
+      });
+    });
+
+    it("denies requests from anonymous users", () => {
+      expect(hasManageUserAccess({ req: {} })).toBe(false);
+      expect(hasManageUserAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.hasEditorAccess", () => {
+    it("allows requests from administrators and editors", () => {
+      expect(hasEditorAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+      expect(hasEditorAccess({ req: { user: { role: ROLE_EDITOR } } })).toBe(
+        true,
+      );
+    });
+
+    it("denies requests from authors and anonymous users", () => {
+      expect(hasEditorAccess({ req: { user: { role: ROLE_AUTHOR } } })).toBe(
+        false,
+      );
+      expect(hasEditorAccess({ req: {} })).toBe(false);
+      expect(hasEditorAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("abilities.hasLoggedInAccess", () => {
+    it("allows requests with users that have valid roles", () => {
+      expect(hasLoggedInAccess({ req: { user: { role: ROLE_ADMIN } } })).toBe(
+        true,
+      );
+      expect(hasLoggedInAccess({ req: { user: { role: ROLE_AUTHOR } } })).toBe(
+        true,
+      );
+      expect(hasLoggedInAccess({ req: { user: { role: ROLE_EDITOR } } })).toBe(
+        true,
+      );
+    });
+
+    it("denies requests without a user that has a valid role", () => {
+      expect(hasLoggedInAccess({ req: { user: { role: "unknown" } } })).toBe(
+        false,
+      );
+      expect(hasLoggedInAccess({ req: { user: 1 } })).toBe(false);
+      expect(hasLoggedInAccess({ req: {} })).toBe(false);
+      expect(hasLoggedInAccess(undefined)).toBe(false);
+    });
+  });
+
+  describe("anyone.anyone", () => {
+    it("allows requests from administrators, authors, editors and anonymous users", () => {
+      expect(anyone({ req: { user: { role: ROLE_ADMIN } } })).toBe(true);
+      expect(anyone({ req: { user: { role: ROLE_AUTHOR } } })).toBe(true);
+      expect(anyone({ req: { user: { role: ROLE_EDITOR } } })).toBe(true);
+      expect(anyone({ req: { user: 1 } })).toBe(true);
+      expect(anyone({ req: {} })).toBe(true);
+      expect(anyone(undefined)).toBe(true);
+    });
+  });
+});

--- a/apps/trustlab/src/payload/access/loggedIn.js
+++ b/apps/trustlab/src/payload/access/loggedIn.js
@@ -1,3 +1,0 @@
-export const loggedIn = (user) => Boolean(user);
-
-export default undefined;

--- a/apps/trustlab/src/payload/access/roles.js
+++ b/apps/trustlab/src/payload/access/roles.js
@@ -6,3 +6,8 @@ export const ROLE_OPTIONS = [
   { label: "Editor", value: ROLE_EDITOR },
   { label: "Author", value: ROLE_AUTHOR },
 ];
+
+export const hasValidRole = (user) =>
+  ROLE_OPTIONS.some(({ value }) => user?.role === value);
+
+export default undefined;

--- a/apps/trustlab/src/payload/collections/Donors.js
+++ b/apps/trustlab/src/payload/collections/Donors.js
@@ -6,6 +6,8 @@ import {
   linkGroup,
 } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
+
 const Donors = {
   slug: "donors",
   labels: {
@@ -23,9 +25,11 @@ const Donors = {
     useAsTitle: "name",
   },
   access: {
-    read: () => true,
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
-
   fields: [
     {
       name: "name",

--- a/apps/trustlab/src/payload/collections/Media.js
+++ b/apps/trustlab/src/payload/collections/Media.js
@@ -2,8 +2,7 @@ import path from "path";
 
 import { createdBy } from "@commons-ui/payload";
 
-import { canManageContent } from "@/trustlab/payload/access/abilities";
-import { anyone } from "@/trustlab/payload/access/anyone";
+import { anyone, hasAuthorAccess } from "@/trustlab/payload/access";
 import { hideAPIURL, slugify } from "@/trustlab/payload/utils";
 
 function slugifyFilename(filename) {
@@ -19,9 +18,9 @@ const Media = {
   slug: "media",
   access: {
     read: anyone,
-    create: ({ req: { user } }) => canManageContent(user),
-    update: ({ req: { user } }) => canManageContent(user),
-    delete: ({ req: { user } }) => canManageContent(user),
+    create: hasAuthorAccess,
+    update: hasAuthorAccess,
+    delete: hasAuthorAccess,
   },
   admin: {
     group: "Publication",

--- a/apps/trustlab/src/payload/collections/Opportunities.js
+++ b/apps/trustlab/src/payload/collections/Opportunities.js
@@ -1,5 +1,6 @@
 import { image, appendPathnameToCollection, slug } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
 import blocks from "@/trustlab/payload/blocks";
 
 const pageByType = {
@@ -25,7 +26,10 @@ const Opportunities = {
     defaultColumns: ["title", "type"],
   },
   access: {
-    read: () => true,
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Organisations.js
+++ b/apps/trustlab/src/payload/collections/Organisations.js
@@ -1,5 +1,6 @@
 import { slug, image, richText, linkGroup } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
 import blocks from "@/trustlab/payload/blocks";
 
 const Organisations = {
@@ -14,7 +15,10 @@ const Organisations = {
     defaultColumns: ["name", "createdAt"],
   },
   access: {
-    read: () => true,
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Pages.js
+++ b/apps/trustlab/src/payload/collections/Pages.js
@@ -1,7 +1,6 @@
 import { appendPathname, fullTitle, slug } from "@commons-ui/payload";
 
-import { canManagePages } from "@/trustlab/payload/access/abilities";
-import { anyone } from "@/trustlab/payload/access/anyone";
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
 import blocks from "@/trustlab/payload/blocks";
 import {
   hideAPIURL,
@@ -14,9 +13,9 @@ const Pages = {
   slug: "pages",
   access: {
     read: anyone,
-    create: ({ req: { user } }) => canManagePages(user),
-    update: ({ req: { user } }) => canManagePages(user),
-    delete: ({ req: { user } }) => canManagePages(user),
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   admin: {
     defaultColumns: ["fullTitle", "updatedAt", "_status"],

--- a/apps/trustlab/src/payload/collections/Partners.js
+++ b/apps/trustlab/src/payload/collections/Partners.js
@@ -6,6 +6,8 @@ import {
   slug,
 } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
+
 const Partners = {
   slug: "partners",
   labels: {
@@ -23,9 +25,11 @@ const Partners = {
     useAsTitle: "name",
   },
   access: {
-    read: () => true,
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
-
   fields: [
     {
       name: "name",

--- a/apps/trustlab/src/payload/collections/Playbooks.js
+++ b/apps/trustlab/src/payload/collections/Playbooks.js
@@ -1,5 +1,7 @@
 import { image, richText, slug } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
+
 const Playbooks = {
   slug: "playbooks",
   labels: { singular: "Playbook", plural: "Playbooks" },
@@ -8,10 +10,10 @@ const Playbooks = {
     defaultColumns: ["title", "updatedAt"],
   },
   access: {
-    read: () => true,
-    create: ({ req: { user } }) => Boolean(user),
-    update: ({ req: { user } }) => Boolean(user),
-    delete: ({ req: { user } }) => Boolean(user),
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Posts.js
+++ b/apps/trustlab/src/payload/collections/Posts.js
@@ -8,8 +8,7 @@ import {
 } from "@commons-ui/payload";
 import { createParentField } from "@payloadcms/plugin-nested-docs";
 
-import { canManageContent } from "@/trustlab/payload/access/abilities";
-import { anyone } from "@/trustlab/payload/access/anyone";
+import { anyone, hasAuthorAccess } from "@/trustlab/payload/access";
 import blocks from "@/trustlab/payload/blocks";
 import { hideAPIURL, revalidatePost } from "@/trustlab/payload/utils";
 
@@ -23,9 +22,9 @@ const Posts = {
   },
   access: {
     read: anyone,
-    create: ({ req: { user } }) => canManageContent(user),
-    update: ({ req: { user } }) => canManageContent(user),
-    delete: ({ req: { user } }) => canManageContent(user),
+    create: hasAuthorAccess,
+    update: hasAuthorAccess,
+    delete: hasAuthorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Reports.js
+++ b/apps/trustlab/src/payload/collections/Reports.js
@@ -5,6 +5,8 @@ import {
   slug,
 } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
+
 const pageByType = {
   baseline: "baseline-reports",
   situational: "situational-reports",
@@ -27,10 +29,10 @@ const Reports = {
     defaultColumns: ["title", "reportType", "updatedAt"],
   },
   access: {
-    read: () => true,
-    create: ({ req: { user } }) => Boolean(user),
-    update: ({ req: { user } }) => Boolean(user),
-    delete: ({ req: { user } }) => Boolean(user),
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Toolkits.js
+++ b/apps/trustlab/src/payload/collections/Toolkits.js
@@ -1,5 +1,7 @@
 import { image, richText, slug, linkGroup } from "@commons-ui/payload";
 
+import { anyone, hasEditorAccess } from "@/trustlab/payload/access";
+
 const Toolkits = {
   slug: "toolkits",
   labels: { singular: "Toolkit", plural: "Toolkits" },
@@ -8,10 +10,10 @@ const Toolkits = {
     defaultColumns: ["title", "updatedAt"],
   },
   access: {
-    read: () => true,
-    create: ({ req: { user } }) => Boolean(user),
-    update: ({ req: { user } }) => Boolean(user),
-    delete: ({ req: { user } }) => Boolean(user),
+    read: anyone,
+    create: hasEditorAccess,
+    update: hasEditorAccess,
+    delete: hasEditorAccess,
   },
   fields: [
     {

--- a/apps/trustlab/src/payload/collections/Users/index.js
+++ b/apps/trustlab/src/payload/collections/Users/index.js
@@ -1,9 +1,9 @@
 import { protectRoleField } from "./hooks/protectRoleField";
 
 import {
-  canCreateAccounts,
-  canManageUsers,
-} from "@/trustlab/payload/access/abilities";
+  hasCreateUserAccess,
+  hasManageUserAccess,
+} from "@/trustlab/payload/access";
 import { ROLE_AUTHOR, ROLE_OPTIONS } from "@/trustlab/payload/access/roles";
 
 const Users = {
@@ -15,11 +15,11 @@ const Users = {
     hideAPIURL: true,
   },
   access: {
-    delete: ({ req: { user } }) => canManageUsers(user),
-    create: ({ req: { user } }) => canCreateAccounts(user),
-    read: ({ req: { user } }) => canManageUsers(user),
-    update: ({ req: { user } }) => canManageUsers(user),
-    unlock: ({ req: { user } }) => canManageUsers(user),
+    delete: hasManageUserAccess,
+    create: hasCreateUserAccess,
+    read: hasManageUserAccess,
+    update: hasManageUserAccess,
+    unlock: hasManageUserAccess,
   },
   auth: true,
   fields: [
@@ -47,7 +47,7 @@ const Users = {
             beforeChange: [protectRoleField],
           },
           access: {
-            update: ({ req: { user } }) => user?.role !== ROLE_AUTHOR,
+            update: hasCreateUserAccess,
           },
         },
       ],

--- a/apps/trustlab/src/payload/globals/index.js
+++ b/apps/trustlab/src/payload/globals/index.js
@@ -1,9 +1,6 @@
 import { EngagementTab, GeneralTab, NavigationTab, SeoTab } from "./tabs";
 
-import {
-  hasLoggedInAccess,
-  hasAdminAccess,
-} from "@/trustlab/payload/access/abilities";
+import { anyone, hasAdminAccess } from "@/trustlab/payload/access";
 import { hideAPIURL } from "@/trustlab/payload/utils";
 
 const SiteSettings = {
@@ -14,9 +11,9 @@ const SiteSettings = {
     hideAPIURL,
   },
   access: {
-    // Since we're using Local APIs, we should still be able to pull data server-side
-    // See: note in https://payloadcms.com/docs/local-api/overview#transactions
-    read: hasLoggedInAccess,
+    // Public rendering paths, including the custom error page REST fallback,
+    // need navbar/footer/settings data before an authenticated CMS session exists.
+    read: anyone,
     update: hasAdminAccess,
   },
   fields: [

--- a/apps/trustlab/src/payload/globals/index.js
+++ b/apps/trustlab/src/payload/globals/index.js
@@ -1,7 +1,9 @@
 import { EngagementTab, GeneralTab, NavigationTab, SeoTab } from "./tabs";
 
-import { loggedIn } from "@/trustlab/payload/access";
-import { canManageSiteSettings } from "@/trustlab/payload/access/abilities";
+import {
+  hasLoggedInAccess,
+  hasAdminAccess,
+} from "@/trustlab/payload/access/abilities";
 import { hideAPIURL } from "@/trustlab/payload/utils";
 
 const SiteSettings = {
@@ -14,8 +16,8 @@ const SiteSettings = {
   access: {
     // Since we're using Local APIs, we should still be able to pull data server-side
     // See: note in https://payloadcms.com/docs/local-api/overview#transactions
-    read: loggedIn,
-    update: canManageSiteSettings,
+    read: hasLoggedInAccess,
+    update: hasAdminAccess,
   },
   fields: [
     {


### PR DESCRIPTION
## Description

`@/trustlab`'s Payload access layer had two categories of issues.

**Authorization gaps** (P1):
- Reports, Playbooks, and Toolkits used `Boolean(user)`, so any authenticated session, regardless of role, could create, update, or delete these collections.
- Partners, Donors, Opportunities, and Organisations had no explicit `create`/`update`/`delete` access at all, relying on Payload's implicit behaviour.
- `SiteSettings` was world-readable: `loggedIn` was defined as `(user) => Boolean(user)` but wired as a Payload access adapter, so Payload called it as `loggedIn({ req })`, which was always truthy.

**Structural issues** that made auditing difficult:
- User-level predicates and Payload access adapters shared the same function signatures, so call sites had to inline `({ req: { user } }) => helper(user)` everywhere.
- `Boolean(user)` trusts any truthy `req.user` value; a token with an arbitrary payload would pass.

### Changes

**Access layer refactor (`src/payload/access/`)**

Introduces a clear three-tier naming convention:

| Tier | Returns | Used by |
|---|---|---|
| `isXxx(user)` | `boolean` | custom route/middleware code |
| `canXxx(user)` | `boolean \| Payload where-filter` | internal policy logic |
| `hasXxxAccess({ req })` | Payload access adapter | collection/global `access:` config |

- `hasValidRole(user)` added to `roles.js`: validates `user.role` against the known role constants. Replaces `Boolean(user)` everywhere.
- `loggedIn.js` removed. `isLoggedIn`, `isEditor`, `isAuthor`, `isAdmin`, `canAuthor`, `canManageUser` are the new user-level predicates.
- `hasLoggedInAccess`, `hasEditorAccess`, `hasAuthorAccess`, `hasAdminAccess`, `hasManageUserAccess`, `hasCreateUserAccess` are the new Payload adapters, each a thin wrapper over the corresponding predicate.

**Collections and globals**

| Surface | Before | After |
|---|---|---|
| Reports, Playbooks, Toolkits (write) | `Boolean(user)` | `hasEditorAccess` |
| Pages (write) | `canManagePages(user)` inline | `hasEditorAccess` |
| Opportunities, Organisations, Partners, Donors (write) | missing (implicit) | `hasEditorAccess` |
| Posts, Media (write) | `canManageContent(user)` inline | `hasAuthorAccess` |
| Users collection | inline wrappers | named adapters; role-field update tightened to `hasCreateUserAccess` |
| SiteSettings read | `loggedIn` (broken — always `true`) | `hasLoggedInAccess` |
| SiteSettings update | `canManageSiteSettings` inline | `hasAdminAccess` |

Posts and Media intentionally remain on `hasAuthorAccess` to preserve the ownership-aware author workflow.

**Preview route**

`preview/route.ts` now uses `isAuthor(user)`, the correct boolean predicate, instead of the old `canManageContent(user)` whose filter-object return value was only coincidentally truthy in a boolean context.

**Tests (`src/payload/access/index.test.js`)**

Full policy matrix at the helper layer: `isAuthor`, `canAuthor`, `hasAuthorAccess`, `hasEditorAccess`, `hasAdminAccess`, `hasLoggedInAccess`, `hasCreateUserAccess`, `hasManageUserAccess`, and `anyone`. Cases cover admin/editor/author/anonymous and invalid-role shapes (`role: "unknown"`, bare integer, `undefined`). The `canAuthor` suite includes the id-guard edge case (author with no `id` returns `false` rather than a filter with `equals: undefined`).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Screenshots

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
