### PR TITLE
Fix participating organisation card links

### DIFF
--- a/apps/trustlab/src/lib/data/blockify/getParticipatingOrganizationListBlock.js
+++ b/apps/trustlab/src/lib/data/blockify/getParticipatingOrganizationListBlock.js
@@ -23,37 +23,28 @@ async function getParticipatingOrganizationListBlock(block, api) {
   const { docs } = await api.findPage(parentSlug, {});
   const doc = docs[0];
   const pagePath = fullSlugFromParents(doc);
-  const resolvedOrganizations = await Promise.all(
-    (organizations || []).map(async (org) => {
-      // Handle both populated and unpopulated relationships
-      const orgData = typeof org === "object" ? org : null;
+  const resolvedOrganizations = (organizations || []).map((org) => {
+    if (!org || typeof org !== "object") {
+      return null;
+    }
 
-      if (!orgData) {
-        return null;
-      }
+    const image = org.image ?? null;
 
-      const image = orgData.image ?? null;
+    // For card variant, generate link from breadcrumbs/slug
+    const href =
+      variant === "card" && org.slug
+        ? `/${[pagePath, org.slug].filter(Boolean).join("/")}`
+        : org.link?.href;
 
-      // For card variant, generate link from breadcrumbs/slug
-      const link =
-        (variant === "card"
-          ? {
-              href: `/${pagePath}/${orgData.slug}`,
-            }
-          : {
-              href: orgData?.link?.href ?? null,
-            }) ?? null;
-
-      return {
-        id: orgData.id,
-        name: orgData.name,
-        description: orgData.description ?? null,
-        image,
-        link,
-        buttonLabel: buttonLabel || "Learn More",
-      };
-    }),
-  );
+    return {
+      id: org.id,
+      name: org.name,
+      description: org.description ?? null,
+      image,
+      link: href ? { href } : null,
+      buttonLabel: buttonLabel || "Learn More",
+    };
+  });
 
   return {
     ...rest,


### PR DESCRIPTION
## Description

This PR fixes TrustLab participating organisation card links so the “Learn More” button points to the organisation detail page instead of `/undefined`. 

### Changes:

- Builds card links from each populated organisation’s slug.
- Produces URLs like /opportunities/organisations/org-slug.
- Keeps external/custom organisation links for non-card variants.
- Simplifies the block mapping by removing unnecessary async relationship handling.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
