### PR TITLE
Configurable OpportunitiesList background + fix admin colour fields

### DIFF
--- a/apps/trustlab/jsconfig.json
+++ b/apps/trustlab/jsconfig.json
@@ -6,10 +6,7 @@
       "@payload-types": ["./payload-types.ts"],
       "@/commons-ui/core/*": ["../../packages/commons-ui-core/src/*"],
       "@/commons-ui/next/*": ["../../packages/commons-ui-next/src/*"],
-      "@/commons-ui/payload/*": ["../../packages/commons-ui-payload/src/*"],
-      "@nouance/payload-better-fields-plugin/*": [
-        "./node_modules/@nouance/payload-better-fields-plugin/dist/exports/*"
-      ]
+      "@/commons-ui/payload/*": ["../../packages/commons-ui-payload/src/*"]
     }
   },
   "exclude": ["node_modules"]

--- a/apps/trustlab/package.json
+++ b/apps/trustlab/package.json
@@ -27,7 +27,6 @@
     "@mui/material": "catalog:",
     "@mui/utils": "catalog:",
     "@next/third-parties": "catalog:",
-    "@nouance/payload-better-fields-plugin": "catalog:payload-v3",
     "@payloadcms/admin-bar": "catalog:payload-v3",
     "@payloadcms/db-mongodb": "catalog:payload-v3",
     "@payloadcms/email-nodemailer": "catalog:payload-v3",

--- a/apps/trustlab/src/app/(payload)/admin/importMap.js
+++ b/apps/trustlab/src/app/(payload)/admin/importMap.js
@@ -21,7 +21,7 @@ import { StrikethroughFeatureClient as StrikethroughFeatureClient_e70f5e05f09f93
 import { UnderlineFeatureClient as UnderlineFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from "@payloadcms/richtext-lexical/client";
 import { BoldFeatureClient as BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from "@payloadcms/richtext-lexical/client";
 import { ItalicFeatureClient as ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864 } from "@payloadcms/richtext-lexical/client";
-import { ColourTextComponent as ColourTextComponent_5eca6d89486e7fecc5e5204e28af0de5 } from "@nouance/payload-better-fields-plugin/ColourText/client";
+import { default as default_2c531646f032a722d2ebb234d9578f69 } from "@/trustlab/payload/components/ColourPicker";
 import { OverviewComponent as OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860 } from "@payloadcms/plugin-seo/client";
 import { MetaTitleComponent as MetaTitleComponent_a8a977ebc872c5d5ea7ee689724c0860 } from "@payloadcms/plugin-seo/client";
 import { MetaDescriptionComponent as MetaDescriptionComponent_a8a977ebc872c5d5ea7ee689724c0860 } from "@payloadcms/plugin-seo/client";
@@ -80,8 +80,8 @@ export const importMap = {
     BoldFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
   "@payloadcms/richtext-lexical/client#ItalicFeatureClient":
     ItalicFeatureClient_e70f5e05f09f93e00b997edb1ef0c864,
-  "@nouance/payload-better-fields-plugin/ColourText/client#ColourTextComponent":
-    ColourTextComponent_5eca6d89486e7fecc5e5204e28af0de5,
+  "@/trustlab/payload/components/ColourPicker#default":
+    default_2c531646f032a722d2ebb234d9578f69,
   "@payloadcms/plugin-seo/client#OverviewComponent":
     OverviewComponent_a8a977ebc872c5d5ea7ee689724c0860,
   "@payloadcms/plugin-seo/client#MetaTitleComponent":

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
@@ -38,6 +38,7 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     defaultSort,
     title,
     description,
+    backgroundColor = "#fff",
     sx,
   } = props;
 
@@ -238,40 +239,33 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
   }
+  const background = backgroundColor;
 
   return (
-    <Box ref={listRef} sx={sx}>
-      <Box sx={{ background: "#fff" }}>
-        {title || description ? (
-          <Section
-            sx={{
-              backgroundColor: "common.white",
-              py: 5,
-              px: { xs: 2.5, md: 0 },
-            }}
-          >
-            <Typography variant="h2">{title}</Typography>
-            {description && (
-              <LexicalRichText
-                elements={description}
-                sx={{
-                  h1: { mb: 1, fontWeight: 700, variant: "h1" },
-                  h2: { mb: 1, fontWeight: 700, variant: "h2" },
-                  h3: { mb: 1, fontWeight: 700, variant: "h3" },
-                }}
-                TypographyProps={{
-                  gutterBottom: true,
-                  variant: "p2",
-                  component: "p",
-                  sx: {
-                    mb: 2,
-                  },
-                }}
-              />
-            )}
-          </Section>
-        ) : null}
-      </Box>
+    <Box ref={listRef} sx={{ background, ...sx }}>
+      {title || description ? (
+        <Section sx={{ pt: 5, pb: 0, px: { xs: 2.5, md: 0 } }}>
+          <Typography variant="h2">{title}</Typography>
+          {description && (
+            <LexicalRichText
+              elements={description}
+              sx={{
+                h1: { mb: 1, fontWeight: 700, variant: "h1" },
+                h2: { mb: 1, fontWeight: 700, variant: "h2" },
+                h3: { mb: 1, fontWeight: 700, variant: "h3" },
+              }}
+              TypographyProps={{
+                gutterBottom: true,
+                variant: "p2",
+                component: "p",
+                sx: {
+                  mb: 2,
+                },
+              }}
+            />
+          )}
+        </Section>
+      ) : null}
 
       {hasFilters || hasSearch || hasSortBy ? (
         <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
@@ -292,39 +286,42 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
           />
         </Section>
       ) : null}
-      <Box sx={{ background: "#fff" }}>
-        {items.length ? (
-          <Box>
-            <Section sx={{ py: 5, px: { xs: 2.5, sm: 0 } }}>
-              <Grid container spacing={3} rowSpacing={3.75}>
-                {items.map((item, index) => (
-                  <Grid key={item.id ?? index} size={{ xs: 12, sm: 6, md: 4 }}>
-                    <OpportunityCard
-                      image={item.image}
-                      title={item.title}
-                      description={item.description}
-                      link={item.link}
-                      caption={item.caption}
-                      location={item.location}
-                      date={item.date}
-                      viewMoreLabel={cardActionLabel}
-                    />
-                  </Grid>
-                ))}
+
+      {items.length ? (
+        <Section
+          sx={{
+            pb: 5,
+            pt: title || description ? 0 : 5,
+            px: { xs: 2.5, sm: 0 },
+          }}
+        >
+          <Grid container spacing={3} rowSpacing={3.75}>
+            {items.map((item, index) => (
+              <Grid key={item.id ?? index} size={{ xs: 12, sm: 6, md: 4 }}>
+                <OpportunityCard
+                  image={item.image}
+                  title={item.title}
+                  description={item.description}
+                  link={item.link}
+                  caption={item.caption}
+                  location={item.location}
+                  date={item.date}
+                  viewMoreLabel={cardActionLabel}
+                />
               </Grid>
-              {hasPagination ? (
-                <Box display="flex" justifyContent="flex-end" mt={4}>
-                  <Pagination
-                    page={pagination?.page ?? 1}
-                    count={pagination?.count ?? 1}
-                    onChange={handlePageChange}
-                  />
-                </Box>
-              ) : null}
-            </Section>
-          </Box>
-        ) : null}
-      </Box>
+            ))}
+          </Grid>
+          {hasPagination ? (
+            <Box display="flex" justifyContent="flex-end" mt={4}>
+              <Pagination
+                page={pagination?.page ?? 1}
+                count={pagination?.count ?? 1}
+                onChange={handlePageChange}
+              />
+            </Box>
+          ) : null}
+        </Section>
+      ) : null}
     </Box>
   );
 });

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
@@ -239,10 +239,8 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
   }
-  const background = backgroundColor;
-
   return (
-    <Box ref={listRef} sx={{ background, ...sx }}>
+    <Box ref={listRef} sx={{ background: backgroundColor, ...sx }}>
       {title || description ? (
         <Section sx={{ pt: 5, pb: 0, px: { xs: 2.5, md: 0 } }}>
           <Typography variant="h2">{title}</Typography>

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
@@ -39,6 +39,7 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     title,
     description,
     backgroundColor = "#fff",
+    textColor = "#000",
     sx,
   } = props;
 
@@ -240,7 +241,10 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     router.push(urlPath, undefined, { shallow: true, scroll: false });
   }
   return (
-    <Box ref={listRef} sx={{ background: backgroundColor, ...sx }}>
+    <Box
+      ref={listRef}
+      sx={{ background: backgroundColor, color: textColor, ...sx }}
+    >
       {title || description ? (
         <Section sx={{ pt: 5, pb: 0, px: { xs: 2.5, md: 0 } }}>
           <Typography variant="h2">{title}</Typography>

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.snap.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.snap.js
@@ -3,7 +3,7 @@
 exports[`<OpportunitiesList /> renders unchanged 1`] = `
 <div>
   <div
-    class="MuiBox-root css-c3vlm2"
+    class="MuiBox-root css-1p6hwme"
   >
     <div
       class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-1xx78f4-MuiContainer-root"

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.snap.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.snap.js
@@ -3,174 +3,163 @@
 exports[`<OpportunitiesList /> renders unchanged 1`] = `
 <div>
   <div
-    class="MuiBox-root css-0"
+    class="MuiBox-root css-c3vlm2"
   >
     <div
-      class="MuiBox-root css-c3vlm2"
-    />
-    <div
-      class="MuiBox-root css-c3vlm2"
+      class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-1xx78f4-MuiContainer-root"
     >
       <div
-        class="MuiBox-root css-0"
+        class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-3 css-suy5xy-MuiGrid2-root"
       >
         <div
-          class="MuiContainer-root MuiContainer-maxWidthLg MuiContainer-fixed MuiContainer-disableGutters css-j09c23-MuiContainer-root"
+          class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-6 MuiGrid2-grid-md-4 css-nv5v9n-MuiGrid2-root"
         >
-          <div
-            class="MuiGrid2-root MuiGrid2-container MuiGrid2-direction-xs-row MuiGrid2-spacing-xs-3 css-suy5xy-MuiGrid2-root"
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1wgs0mi-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
+            href="/items/1"
+            style="--Paper-shadow: none;"
           >
             <div
-              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-6 MuiGrid2-grid-md-4 css-nv5v9n-MuiGrid2-root"
+              class="MuiBox-root css-1xvjh2y"
             >
-              <a
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1wgs0mi-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
-                href="/items/1"
-                style="--Paper-shadow: none;"
-              >
-                <div
-                  class="MuiBox-root css-1xvjh2y"
-                >
-                  <img
-                    alt="Item 1"
-                    class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-1v4c65z-MuiCardMedia-root"
-                    decoding="async"
-                    loading="lazy"
-                    src="/images/item1.jpg"
-                  />
-                  <div
-                    class="overlay MuiBox-root css-b5sikr"
-                  />
-                </div>
-                <div
-                  class="MuiCardContent-root css-40lmnp-MuiCardContent-root"
-                >
-                  <div
-                    class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom css-1iltire-MuiTypography-root"
-                  >
-                    Test Item 1
-                  </div>
-                  <div
-                    class="MuiTypography-root MuiTypography-p2 css-7e94g1-MuiTypography-root"
-                  >
-                    Category | Type
-                  </div>
-                  <div
-                    class="MuiStack-root css-niqf4j-MuiStack-root"
-                  >
-                    <div
-                      class="MuiTypography-root MuiTypography-p2 css-1e8bnay-MuiTypography-root"
-                    >
-                      Nairobi, Kenya
-                    </div>
-                    <div
-                      aria-orientation="vertical"
-                      class="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-x39m9m-MuiDivider-root"
-                      role="separator"
-                    />
-                    <div
-                      class="MuiTypography-root MuiTypography-p2 css-1pscdoi-MuiTypography-root"
-                    >
-                      15-01-2024
-                    </div>
-                  </div>
-                  <div
-                    class="MuiBox-root css-0"
-                  >
-                    <div
-                      class="MuiBox-root css-1haxbqe"
-                    >
-                      <div
-                        class="MuiBox-root css-0"
-                      >
-                        Description for item 1
-                      </div>
-                    </div>
-                    <button
-                      class="MuiTypography-root MuiTypography-p2 css-3vk8dq-MuiTypography-root"
-                    >
-                      View more
-                    </button>
-                  </div>
-                </div>
-              </a>
+              <img
+                alt="Item 1"
+                class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-1v4c65z-MuiCardMedia-root"
+                decoding="async"
+                loading="lazy"
+                src="/images/item1.jpg"
+              />
+              <div
+                class="overlay MuiBox-root css-b5sikr"
+              />
             </div>
             <div
-              class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-6 MuiGrid2-grid-md-4 css-nv5v9n-MuiGrid2-root"
+              class="MuiCardContent-root css-40lmnp-MuiCardContent-root"
             >
-              <a
-                class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1wgs0mi-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
-                href="/items/2"
-                style="--Paper-shadow: none;"
+              <div
+                class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom css-1iltire-MuiTypography-root"
+              >
+                Test Item 1
+              </div>
+              <div
+                class="MuiTypography-root MuiTypography-p2 css-7e94g1-MuiTypography-root"
+              >
+                Category | Type
+              </div>
+              <div
+                class="MuiStack-root css-niqf4j-MuiStack-root"
               >
                 <div
-                  class="MuiBox-root css-1xvjh2y"
+                  class="MuiTypography-root MuiTypography-p2 css-1e8bnay-MuiTypography-root"
                 >
-                  <img
-                    alt="Item 2"
-                    class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-1v4c65z-MuiCardMedia-root"
-                    decoding="async"
-                    loading="lazy"
-                    src="/images/item2.jpg"
-                  />
-                  <div
-                    class="overlay MuiBox-root css-b5sikr"
-                  />
+                  Nairobi, Kenya
                 </div>
                 <div
-                  class="MuiCardContent-root css-40lmnp-MuiCardContent-root"
+                  aria-orientation="vertical"
+                  class="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-x39m9m-MuiDivider-root"
+                  role="separator"
+                />
+                <div
+                  class="MuiTypography-root MuiTypography-p2 css-1pscdoi-MuiTypography-root"
                 >
-                  <div
-                    class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom css-1iltire-MuiTypography-root"
-                  >
-                    Test Item 2
-                  </div>
-                  <div
-                    class="MuiTypography-root MuiTypography-p2 css-7e94g1-MuiTypography-root"
-                  >
-                    Category | Report
-                  </div>
-                  <div
-                    class="MuiStack-root css-niqf4j-MuiStack-root"
-                  >
-                    <div
-                      class="MuiTypography-root MuiTypography-p2 css-1e8bnay-MuiTypography-root"
-                    >
-                      Mombasa, Kenya
-                    </div>
-                    <div
-                      aria-orientation="vertical"
-                      class="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-x39m9m-MuiDivider-root"
-                      role="separator"
-                    />
-                    <div
-                      class="MuiTypography-root MuiTypography-p2 css-1pscdoi-MuiTypography-root"
-                    >
-                      20-01-2024
-                    </div>
-                  </div>
+                  15-01-2024
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <div
+                  class="MuiBox-root css-1haxbqe"
+                >
                   <div
                     class="MuiBox-root css-0"
                   >
-                    <div
-                      class="MuiBox-root css-1haxbqe"
-                    >
-                      <div
-                        class="MuiBox-root css-0"
-                      >
-                        Description for item 2
-                      </div>
-                    </div>
-                    <button
-                      class="MuiTypography-root MuiTypography-p2 css-3vk8dq-MuiTypography-root"
-                    >
-                      View more
-                    </button>
+                    Description for item 1
                   </div>
                 </div>
-              </a>
+                <button
+                  class="MuiTypography-root MuiTypography-p2 css-3vk8dq-MuiTypography-root"
+                >
+                  View more
+                </button>
+              </div>
             </div>
-          </div>
+          </a>
+        </div>
+        <div
+          class="MuiGrid2-root MuiGrid2-direction-xs-row MuiGrid2-grid-xs-12 MuiGrid2-grid-sm-6 MuiGrid2-grid-md-4 css-nv5v9n-MuiGrid2-root"
+        >
+          <a
+            class="MuiTypography-root MuiTypography-inherit MuiLink-root MuiLink-underlineAlways MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 MuiCard-root css-1wgs0mi-MuiTypography-root-MuiLink-root-MuiPaper-root-MuiCard-root"
+            href="/items/2"
+            style="--Paper-shadow: none;"
+          >
+            <div
+              class="MuiBox-root css-1xvjh2y"
+            >
+              <img
+                alt="Item 2"
+                class="MuiCardMedia-root MuiCardMedia-media MuiCardMedia-img css-1v4c65z-MuiCardMedia-root"
+                decoding="async"
+                loading="lazy"
+                src="/images/item2.jpg"
+              />
+              <div
+                class="overlay MuiBox-root css-b5sikr"
+              />
+            </div>
+            <div
+              class="MuiCardContent-root css-40lmnp-MuiCardContent-root"
+            >
+              <div
+                class="MuiTypography-root MuiTypography-h3 MuiTypography-gutterBottom css-1iltire-MuiTypography-root"
+              >
+                Test Item 2
+              </div>
+              <div
+                class="MuiTypography-root MuiTypography-p2 css-7e94g1-MuiTypography-root"
+              >
+                Category | Report
+              </div>
+              <div
+                class="MuiStack-root css-niqf4j-MuiStack-root"
+              >
+                <div
+                  class="MuiTypography-root MuiTypography-p2 css-1e8bnay-MuiTypography-root"
+                >
+                  Mombasa, Kenya
+                </div>
+                <div
+                  aria-orientation="vertical"
+                  class="MuiDivider-root MuiDivider-middle MuiDivider-vertical MuiDivider-flexItem css-x39m9m-MuiDivider-root"
+                  role="separator"
+                />
+                <div
+                  class="MuiTypography-root MuiTypography-p2 css-1pscdoi-MuiTypography-root"
+                >
+                  20-01-2024
+                </div>
+              </div>
+              <div
+                class="MuiBox-root css-0"
+              >
+                <div
+                  class="MuiBox-root css-1haxbqe"
+                >
+                  <div
+                    class="MuiBox-root css-0"
+                  >
+                    Description for item 2
+                  </div>
+                </div>
+                <button
+                  class="MuiTypography-root MuiTypography-p2 css-3vk8dq-MuiTypography-root"
+                >
+                  View more
+                </button>
+              </div>
+            </div>
+          </a>
         </div>
       </div>
     </div>

--- a/apps/trustlab/src/components/ParticipatingOrganizationList/CardList.js
+++ b/apps/trustlab/src/components/ParticipatingOrganizationList/CardList.js
@@ -1,5 +1,5 @@
 import { Section } from "@commons-ui/core";
-import { Figure, Link } from "@commons-ui/next";
+import { Link } from "@commons-ui/next";
 import { LexicalRichText } from "@commons-ui/payload";
 import { Box, Button, Card, Grid2 as Grid, Typography } from "@mui/material";
 import { forwardRef } from "react";
@@ -61,42 +61,6 @@ const CardList = forwardRef(function CardList(props, ref) {
                       mb: 2,
                     }}
                   >
-                    {org.image ? (
-                      <Figure
-                        ImageProps={{
-                          alt: org.image.alt || org.name,
-                          src: org.image.src,
-                          sx: {
-                            objectFit: "contain",
-                          },
-                        }}
-                        sx={{
-                          width: 56,
-                          height: 56,
-                          minWidth: 56,
-                          borderRadius: "50%",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          overflow: "hidden",
-                        }}
-                      />
-                    ) : (
-                      <Box
-                        sx={{
-                          width: 56,
-                          height: 56,
-                          minWidth: 56,
-                          borderRadius: "50%",
-                          backgroundColor: "#4A4A68",
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
-                          fontSize: "0.75rem",
-                          fontWeight: 700,
-                        }}
-                      />
-                    )}
                     <Typography
                       variant="p2"
                       sx={{

--- a/apps/trustlab/src/payload/blocks/ActionBanner.js
+++ b/apps/trustlab/src/payload/blocks/ActionBanner.js
@@ -1,9 +1,10 @@
 import { richText, linkGroup } from "@commons-ui/payload/fields";
-import { ColourTextField } from "@nouance/payload-better-fields-plugin/ColourText";
 import validateColorModule from "validate-color";
-const { validateHTMLColorHex } = validateColorModule;
 
 import colorSettingsField from "../fields/colorSettingsField";
+import colourTextField from "../fields/colourTextField";
+
+const { validateHTMLColorHex } = validateColorModule;
 
 const validateColor = (value) =>
   validateHTMLColorHex(value) || "Invalid hex color";
@@ -32,7 +33,7 @@ const ActionBanner = {
       type: "group",
       required: true,
       fields: [
-        ...ColourTextField({
+        ...colourTextField({
           name: "borderColor",
           admin: {
             description: "Border Color of Action button",

--- a/apps/trustlab/src/payload/blocks/OpportunitiesList.js
+++ b/apps/trustlab/src/payload/blocks/OpportunitiesList.js
@@ -1,5 +1,7 @@
 import { richText } from "@commons-ui/payload/fields";
 
+import colorSettingsField from "../fields/colorSettingsField";
+
 const OpportunitiesList = {
   slug: "opportunities-list",
   labels: { singular: "Opportunities List", plural: "Opportunities Lists" },
@@ -14,6 +16,10 @@ const OpportunitiesList = {
     richText({
       name: "description",
       localized: true,
+    }),
+    colorSettingsField({
+      backgroundOverrides: { defaultValue: "#fff" },
+      textOverrides: { defaultValue: "#000" },
     }),
     {
       name: "opportunityType",

--- a/apps/trustlab/src/payload/components/ColourPicker.js
+++ b/apps/trustlab/src/payload/components/ColourPicker.js
@@ -19,6 +19,10 @@ export function ColourPicker(props) {
   const { label, required, admin: { description } = {} } = field ?? {};
   const { value, setValue, showError, errorMessage } = useField({ path });
 
+  // Both inputs fall back to the same colour so the swatch and the hex text
+  // never disagree when no value is stored (e.g. a new or cleared field).
+  const colour = value || "#ffffff";
+
   return (
     <div className={`field-type text${showError ? " error" : ""}`}>
       <FieldLabel label={label} path={path} required={required} />
@@ -26,7 +30,7 @@ export function ColourPicker(props) {
         <input
           type="color"
           aria-label={`${typeof label === "string" ? label : "Colour"} swatch`}
-          value={value || "#ffffff"}
+          value={colour}
           onChange={(e) => setValue(e.target.value)}
           style={{
             width: "40px",
@@ -40,7 +44,7 @@ export function ColourPicker(props) {
         />
         <input
           type="text"
-          value={value || ""}
+          value={colour}
           placeholder="#ffffff"
           onChange={(e) => setValue(e.target.value)}
           style={{ flex: 1 }}

--- a/apps/trustlab/src/payload/components/ColourPicker.js
+++ b/apps/trustlab/src/payload/components/ColourPicker.js
@@ -1,0 +1,57 @@
+"use client";
+
+import {
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  useField,
+} from "@payloadcms/ui";
+import React from "react";
+
+// Native Payload v3 client component used as the `Field` for colour fields
+// produced by colourTextField. Replaces the legacy
+// @nouance/payload-better-fields-plugin ColourText component, which is built for
+// an older @payloadcms/ui and crashes under the version this app runs. It binds
+// to the field value via useField (no extra state) and renders a native colour
+// swatch alongside a hex text input that stay in sync.
+export function ColourPicker(props) {
+  const { field, path } = props;
+  const { label, required, admin: { description } = {} } = field ?? {};
+  const { value, setValue, showError, errorMessage } = useField({ path });
+
+  return (
+    <div className={`field-type text${showError ? " error" : ""}`}>
+      <FieldLabel label={label} path={path} required={required} />
+      <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
+        <input
+          type="color"
+          aria-label={`${typeof label === "string" ? label : "Colour"} swatch`}
+          value={value || "#ffffff"}
+          onChange={(e) => setValue(e.target.value)}
+          style={{
+            width: "40px",
+            height: "40px",
+            flexShrink: 0,
+            padding: 0,
+            border: "none",
+            background: "none",
+            cursor: "pointer",
+          }}
+        />
+        <input
+          type="text"
+          value={value || ""}
+          placeholder="#ffffff"
+          onChange={(e) => setValue(e.target.value)}
+          style={{ flex: 1 }}
+        />
+      </div>
+      <FieldError path={path} showError={showError} message={errorMessage} />
+      {description ? (
+        <FieldDescription path={path} description={description} />
+      ) : null}
+    </div>
+  );
+}
+
+export default ColourPicker;

--- a/apps/trustlab/src/payload/fields/colorSettingsField.js
+++ b/apps/trustlab/src/payload/fields/colorSettingsField.js
@@ -1,6 +1,8 @@
 import { deepmerge } from "@mui/utils";
-import { ColourTextField } from "@nouance/payload-better-fields-plugin/ColourText";
 import validateColorModule from "validate-color";
+
+import colourTextField from "./colourTextField";
+
 const { validateHTMLColorHex } = validateColorModule;
 
 const validate = (value) => validateHTMLColorHex(value) || "Invalid hex color";
@@ -33,7 +35,7 @@ const colorSettingsField = ({
   );
   return {
     type: "row",
-    fields: [...ColourTextField(background), ...ColourTextField(text)],
+    fields: [...colourTextField(background), ...colourTextField(text)],
   };
 };
 

--- a/apps/trustlab/src/payload/fields/colorSettingsField.js
+++ b/apps/trustlab/src/payload/fields/colorSettingsField.js
@@ -5,7 +5,12 @@ import colourTextField from "./colourTextField";
 
 const { validateHTMLColorHex } = validateColorModule;
 
-const validate = (value) => validateHTMLColorHex(value) || "Invalid hex color";
+const validate = (value) => {
+  if (!value) {
+    return "This field is required";
+  }
+  return validateHTMLColorHex(value) || "Invalid hex color";
+};
 const colorSettingsField = ({
   backgroundOverrides = {},
   textOverrides = {},

--- a/apps/trustlab/src/payload/fields/colourTextField.js
+++ b/apps/trustlab/src/payload/fields/colourTextField.js
@@ -1,0 +1,28 @@
+import { deepmerge } from "@mui/utils";
+
+// Local drop-in replacement for @nouance/payload-better-fields-plugin's
+// ColourTextField. The plugin's client Field component is built against an
+// older @payloadcms/ui and crashes under the version this app runs
+// ("Cannot destructure property 'config' of ... as it is undefined"), taking
+// down the edit view of every block that renders a colour field. This emits a
+// native text field rendered by our own ColourPicker client component (a colour
+// swatch + hex input), so it uses the app's @payloadcms/ui instance and stays
+// compatible. Validation/defaults are preserved via overrides.
+const colourTextField = (overrides = {}) => {
+  const field = deepmerge(
+    {
+      name: "colour",
+      type: "text",
+      admin: {
+        description: "Color in hex format (e.g. #FFFFFF)",
+        components: {
+          Field: "@/trustlab/payload/components/ColourPicker",
+        },
+      },
+    },
+    overrides,
+  );
+  return [field];
+};
+
+export default colourTextField;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -584,9 +584,6 @@ catalogs:
       specifier: ^5.16.6
       version: 5.17.1
   payload-v3:
-    '@nouance/payload-better-fields-plugin':
-      specifier: ^2.0.2
-      version: 2.0.2
     '@payloadcms/admin-bar':
       specifier: ^3.66.0
       version: 3.83.0
@@ -2108,9 +2105,6 @@ importers:
       '@next/third-parties':
         specifier: 'catalog:'
         version: 15.5.15(next@15.5.15(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
-      '@nouance/payload-better-fields-plugin':
-        specifier: catalog:payload-v3
-        version: 2.0.2(colord@2.9.3)(date-fns-tz@2.0.1(date-fns@4.1.0))(payload@3.83.0(graphql@16.13.2)(typescript@5.9.3))(react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-number-format@5.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-phone-number-input@3.4.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(slug@10.0.0)
       '@payloadcms/admin-bar':
         specifier: catalog:payload-v3
         version: 3.83.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5894,18 +5888,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@nouance/payload-better-fields-plugin@2.0.2':
-    resolution: {integrity: sha512-LMio+mqzArm8rT7DP/he9H96BBu1s16aWoh66NWaO50+bMWKnnQwa7XGt8Sixinv4yUn1FCTkvyz0GcjcxNHQw==}
-    engines: {node: ^18.20.2 || >=20.9.0}
-    peerDependencies:
-      colord: ^2.9.3
-      date-fns-tz: ^2.0.1
-      payload: ^3.22.0
-      react-colorful: ^5.6.1
-      react-number-format: ^5.3.1
-      react-phone-number-input: ^3.3.7
-      slug: ^10.0.0
-
   '@npmcli/config@8.3.4':
     resolution: {integrity: sha512-01rtHedemDNhUXdicU7s+QYz/3JyV5Naj84cvdXGH4mgCdL+agmSYaLF4LUG4vMCLzhBO8YtS0gPpH1FGvbgAw==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -9041,9 +9023,6 @@ packages:
     resolution: {integrity: sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==}
     engines: {node: '>=18'}
 
-  colord@2.9.3:
-    resolution: {integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==}
-
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -9214,9 +9193,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  country-flag-icons@1.6.16:
-    resolution: {integrity: sha512-HxJVoE/aaZGcUMx1vK/u9430uKGB3ODZDDZJJOqVJQzoHk5v42c0fSp1rk4tDfyr1dVOJjwxRiaBPliBMo2Liw==}
 
   crawler-user-agents@1.43.0:
     resolution: {integrity: sha512-fw9UPHWOVy1eJ784y3Y80r+acS2Ke85eYnuga8vnd1i8pbpoSD+j9e3lLp/O9X8cviq88llZZRN4Sgjmydguwg==}
@@ -9490,11 +9466,6 @@ packages:
 
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
-
-  date-fns-tz@2.0.1:
-    resolution: {integrity: sha512-fJCG3Pwx8HUoLhkepdsP7Z5RsucUi+ZBOxyM5d0ZZ6c4SdYustq0VMmOu6Wf7bli+yS/Jwp91TOCqn9jMcVrUA==}
-    peerDependencies:
-      date-fns: 2.x
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -11173,17 +11144,6 @@ packages:
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
-  input-format@0.3.14:
-    resolution: {integrity: sha512-gHMrgrbCgmT4uK5Um5eVDUohuV9lcs95ZUUN9Px2Y0VIfjTzT2wF8Q3Z4fwLFm7c5Z2OXCm53FHoovj6SlOKdg==}
-    peerDependencies:
-      react: '>=18.1.0'
-      react-dom: '>=18.1.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   install@0.13.0:
     resolution: {integrity: sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==}
     engines: {node: '>= 0.10'}
@@ -11927,9 +11887,6 @@ packages:
     resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
     engines: {node: '>=16'}
     hasBin: true
-
-  libphonenumber-js@1.12.41:
-    resolution: {integrity: sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==}
 
   lie@3.1.1:
     resolution: {integrity: sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==}
@@ -13816,12 +13773,6 @@ packages:
       react: '>=15.6.2'
       react-dom: '>=15.6.2'
 
-  react-colorful@5.6.1:
-    resolution: {integrity: sha512-1exovf0uGTGyq5mXQT0zgQ80uvj2PCwvF8zY1RN9/vbJVSjSo3fsB/4L3ObbF7u70NduSiK4xu4Y6q1MHoUGEw==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
   react-copy-to-clipboard@5.1.1:
     resolution: {integrity: sha512-s+HrzLyJBxrpGTYXF15dTgMjAJpEPZT/Yp6NytAtZMRngejxt6Pt5WrfFxLAcsqUDU6sY1Jz6tyHwIicE1U2Xg==}
     peerDependencies:
@@ -13947,23 +13898,11 @@ packages:
     resolution: {integrity: sha512-sAX5I9Xec3MR9FxLgZYcYqNnY8M8zJxRRwRipMPtuh4BGvcvoptJfX8Z6nRn0ROMkqVO72iAmb83GlqmSW4Gqw==}
     engines: {node: '>=8'}
 
-  react-number-format@5.4.5:
-    resolution: {integrity: sha512-y8O2yHHj3w0aE9XO8d2BCcUOOdQTRSVq+WIuMlLVucAm5XNjJAy+BoOJiuQMldVYVOKTMyvVNfnbl2Oqp+YxGw==}
-    peerDependencies:
-      react: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-onclickoutside@6.13.2:
     resolution: {integrity: sha512-h6Hbf1c8b7tIYY4u90mDdBLY4+AGQVMFtIE89HgC0DtVCh/JfKl477gYqUtGLmjZBKK3MJxomP/lFiLbz4sq9A==}
     peerDependencies:
       react: ^15.5.x || ^16.x || ^17.x || ^18.x
       react-dom: ^15.5.x || ^16.x || ^17.x || ^18.x
-
-  react-phone-number-input@3.4.16:
-    resolution: {integrity: sha512-ix1+SIyGuLxnlAeW+XQNhwOmmDd4Zmr6Ng1eQl0E2XS8xIuue3gdZeBG4LGTMjTIFneOTO9pUPL+AEDhV6+r+A==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
 
   react-popper@2.3.0:
     resolution: {integrity: sha512-e1hj8lL3uM+sgSR4Lxzn5h1GxBlpa4CQz0XLF8kx4MDrDRWY0Ena4c97PUeSX9i5W3UAfDP0z0FXCTQkoXUl3Q==}
@@ -14634,10 +14573,6 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
-
-  slug@10.0.0:
-    resolution: {integrity: sha512-M8s2PWOUeSCdD4S1NH5lCzXg2zFV1fozrtfr0FSKl65x+EF1rUowj+/vyFlnHgxPxWzT+DL0VXKfYc1DHJoymg==}
-    hasBin: true
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -19764,16 +19699,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@nouance/payload-better-fields-plugin@2.0.2(colord@2.9.3)(date-fns-tz@2.0.1(date-fns@4.1.0))(payload@3.83.0(graphql@16.13.2)(typescript@5.9.3))(react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-number-format@5.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-phone-number-input@3.4.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(slug@10.0.0)':
-    dependencies:
-      colord: 2.9.3
-      date-fns-tz: 2.0.1(date-fns@4.1.0)
-      payload: 3.83.0(graphql@16.13.2)(typescript@5.9.3)
-      react-colorful: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-number-format: 5.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react-phone-number-input: 3.4.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      slug: 10.0.0
-
   '@npmcli/config@8.3.4':
     dependencies:
       '@npmcli/map-workspaces': 3.0.6
@@ -24140,8 +24065,6 @@ snapshots:
       color-convert: 3.1.3
       color-string: 2.1.4
 
-  colord@2.9.3: {}
-
   colorette@2.0.20: {}
 
   combined-stream@1.0.8:
@@ -24306,8 +24229,6 @@ snapshots:
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 5.9.3
-
-  country-flag-icons@1.6.16: {}
 
   crawler-user-agents@1.43.0: {}
 
@@ -24630,10 +24551,6 @@ snapshots:
   dataloader@2.2.2: {}
 
   dataloader@2.2.3: {}
-
-  date-fns-tz@2.0.1(date-fns@4.1.0):
-    dependencies:
-      date-fns: 4.1.0
 
   date-fns@2.30.0:
     dependencies:
@@ -26916,13 +26833,6 @@ snapshots:
 
   inline-style-parser@0.2.7: {}
 
-  input-format@0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      prop-types: 15.8.1
-    optionalDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   install@0.13.0: {}
 
   internal-slot@1.1.0:
@@ -28058,8 +27968,6 @@ snapshots:
   lib0@0.2.117:
     dependencies:
       isomorphic.js: 0.2.5
-
-  libphonenumber-js@1.12.41: {}
 
   lie@3.1.1:
     dependencies:
@@ -30504,11 +30412,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  react-colorful@5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   react-copy-to-clipboard@5.1.1(react@18.3.1):
     dependencies:
       copy-to-clipboard: 3.3.3
@@ -30654,23 +30557,8 @@ snapshots:
       install: 0.13.0
       npm: 10.9.8
 
-  react-number-format@5.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   react-onclickoutside@6.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  react-phone-number-input@3.4.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      classnames: 2.5.1
-      country-flag-icons: 1.6.16
-      input-format: 0.3.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      libphonenumber-js: 1.12.41
-      prop-types: 15.8.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -31616,8 +31504,6 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
-
-  slug@10.0.0: {}
 
   smart-buffer@4.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -237,7 +237,6 @@ catalogs:
     "@mui/utils": ^5.16.6
     "@mui/private-theming": ^5.16.6
   payload-v3:
-    "@nouance/payload-better-fields-plugin": ^2.0.2
     "@payloadcms/admin-bar": ^3.66.0
     "@payloadcms/db-mongodb": ^3.66.0
     "@payloadcms/email-nodemailer": ^3.66.0


### PR DESCRIPTION
## Summary

This started as making the **OpportunitiesList** section background editable from the CMS, and grew to fix a crash that broke the admin edit view for **every** block with a colour field — then remove the dependency responsible for it.

## OpportunitiesList background

- The block background was **hard-coded** (`"red"`). It's now driven by Payload via the shared `colorSettingsField`, defaulting to `#fff`. The component reads `backgroundColor` directly (fallback `#fff`).
- **Fixed the grey band** that appeared between the title and the cards. It was caused by margin-collapse: the description's bottom margin escaped through a `pb: 0` Section because the title and cards lived in two separately-wrapped background boxes. The markup is now a single background-carrying `Box` with the three `Section`s as direct children — cleaner structure, no band, layout unchanged.
- Snapshot refreshed for the new DOM.

## Admin colour fields crash (root cause)

Opening any block with a colour field in the admin threw:

> `TypeError: Cannot destructure property 'config' of ... as it is undefined` — in `ColourTextComponent`

**Cause:** `@nouance/payload-better-fields-plugin@2.0.2` (latest published, built for `@payloadcms/ui` ~3.22) is incompatible with the `@payloadcms/ui` **3.83** this app runs. Its client field component fails inside `useField`. `colorSettingsField` is used by **8 blocks** (OpportunitiesList, Hero, BannerBlock, ActionBanner, Content, WhereWeWork, PageOverview, OpportunityOverview), so all of them were broken — not just OpportunitiesList.

**Fix:** stop routing through the plugin. A native Payload v3 client component (`ColourPicker`) renders a colour **swatch + hex input** bound via `useField`, wired through a local `colourTextField` helper that replaces the plugin's `ColourTextField`. Because it's app-local, it uses the app's own `@payloadcms/ui` instance and is version-compatible. `colorSettingsField` keeps its public API, so every block is fixed at once with no per-block churn.

The now-unused plugin is **removed** from the dependencies, the `payload-v3` catalog, the jsconfig path alias, and the lockfile.

## Review fixes (addressed in this PR)

- **ColourPicker:** swatch and hex text input share one `value || "#ffffff"` fallback, so they never disagree when no value is stored.
- **OpportunitiesList:** use `backgroundColor` directly, dropping a redundant intermediate variable.
- **colorSettingsField:** empty values now return `"This field is required"` instead of the misleading `"Invalid hex color"`.

## Changes

| File | Change |
| --- | --- |
| `payload/blocks/OpportunitiesList.js` | Add `backgroundColor`/`textColor` via `colorSettingsField` (default `#fff`) |
| `components/OpportunitiesList/OpportunitiesList.js` | Read `backgroundColor`; flatten Section structure; remove grey band |
| `components/OpportunitiesList/OpportunitiesList.snap.js` | Snapshot update |
| `payload/components/ColourPicker.js` | **New** native colour-picker client component (swatch + hex) |
| `payload/fields/colourTextField.js` | **New** local replacement for the plugin's `ColourTextField` |
| `payload/fields/colorSettingsField.js` | Use `colourTextField`; required-vs-invalid validation message |
| `payload/blocks/ActionBanner.js` | `borderColor` uses the local helper |
| `app/(payload)/admin/importMap.js` | Regenerated: `ColourTextComponent` → `ColourPicker` |
| `components/ParticipatingOrganizationList/CardList.js` | Drop unused organisation avatar rendering (was staged alongside) |
| `apps/trustlab/package.json`, `pnpm-workspace.yaml`, `jsconfig.json`, `pnpm-lock.yaml` | Remove the unused `@nouance/payload-better-fields-plugin` |

## Before
<img width="1915" height="658" alt="image" src="https://github.com/user-attachments/assets/58ec7afb-2553-4bb4-8975-2c6cef17bcbf" />

- Spacing between description and images is off.
- The background colour is white.
- Participating organisation card had an image.

## After
<img width="1599" height="380" alt="image" src="https://github.com/user-attachments/assets/9e575361-9efb-4bd8-98f7-9ff37e05f675" />
<img width="1782" height="487" alt="image" src="https://github.com/user-attachments/assets/4fa262e2-a3f9-4c0b-8dc7-39676849e9ae" />

- Background color is now configured from payloadcms.
- Removed image from card variant of participating organisation.
- No more crashes on admin blocks with color picker.

## Compatibility

- Stored `backgroundColor` / `textColor` values are unchanged; existing content and the frontend are unaffected.
- No data migration needed — `colorSettingsField`'s public API is unchanged.

## Testing

- `eslint` clean on all changed files; OpportunitiesList unit tests + snapshot pass.
- Admin: open OpportunitiesList (and e.g. Hero) — colour fields render a swatch + hex input, edit view loads without the error boundary.

