### PR TITLE
Guard against missing date and location in opportunities

### DIFF
--- a/apps/trustlab/src/lib/data/pagify/opportunities.js
+++ b/apps/trustlab/src/lib/data/pagify/opportunities.js
@@ -32,7 +32,7 @@ function pagifyOpportunities(collection) {
         return {
           ...block,
           date,
-          location: doc?.location ?? null,
+          location: doc.location || null,
           title: block.title || "Overview",
         };
       }

--- a/apps/trustlab/src/lib/data/pagify/opportunities.js
+++ b/apps/trustlab/src/lib/data/pagify/opportunities.js
@@ -32,7 +32,7 @@ function pagifyOpportunities(collection) {
         return {
           ...block,
           date,
-          location: doc.location,
+          location: doc?.location ?? null,
           title: block.title || "Overview",
         };
       }

--- a/apps/trustlab/src/payload/utils/formatDate.js
+++ b/apps/trustlab/src/payload/utils/formatDate.js
@@ -1,8 +1,12 @@
 const formatDate = (date, options = {}) => {
-  const { locale = "en", includeTime, ...restOptions } = options;
-  if (!date) {
+  if (!date?.length) {
     return null;
   }
+  const parsedDate = new Date(date);
+  if (Number.isNaN(parsedDate.getTime())) {
+    return null;
+  }
+  const { locale = "en", includeTime, ...restOptions } = options;
   const formatOptions = {
     ...(includeTime
       ? { hour: "numeric", minute: "numeric", second: "2-digit" }
@@ -10,7 +14,7 @@ const formatDate = (date, options = {}) => {
     ...restOptions,
   };
   try {
-    const formattedDate = new Date(date).toLocaleString(locale, {
+    const formattedDate = parsedDate.toLocaleString(locale, {
       year: "numeric",
       month: "long",
       day: "numeric",

--- a/apps/trustlab/src/payload/utils/formatDate.js
+++ b/apps/trustlab/src/payload/utils/formatDate.js
@@ -1,6 +1,8 @@
 const formatDate = (date, options = {}) => {
   const { locale = "en", includeTime, ...restOptions } = options;
-
+  if (!date) {
+    return null;
+  }
   const formatOptions = {
     ...(includeTime
       ? { hour: "numeric", minute: "numeric", second: "2-digit" }

--- a/apps/trustlab/src/payload/utils/formatDate.test.js
+++ b/apps/trustlab/src/payload/utils/formatDate.test.js
@@ -1,0 +1,31 @@
+import formatDate from "./formatDate";
+
+describe("payload.utils.formatDate", () => {
+  it("returns null for missing dates", () => {
+    expect(formatDate()).toBeNull();
+    expect(formatDate(null)).toBeNull();
+    expect(formatDate(undefined)).toBeNull();
+    expect(formatDate("")).toBeNull();
+  });
+
+  it("formats a valid date", () => {
+    expect(formatDate("2024-01-15", { locale: "en-US" })).toBe(
+      "January 15, 2024",
+    );
+  });
+
+  it("includes the time when includeTime is set", () => {
+    const formatted = formatDate("2024-01-15T13:45:30Z", {
+      locale: "en-US",
+      includeTime: true,
+      timeZone: "UTC",
+    });
+
+    expect(formatted).toContain("January 15, 2024");
+    expect(formatted).toMatch(/1:45/);
+  });
+
+  it("returns null when formatting throws", () => {
+    expect(formatDate("2024-01-15", { locale: "!!bad locale" })).toBeNull();
+  });
+});

--- a/apps/trustlab/src/payload/utils/formatDate.test.js
+++ b/apps/trustlab/src/payload/utils/formatDate.test.js
@@ -1,11 +1,22 @@
 import formatDate from "./formatDate";
 
 describe("payload.utils.formatDate", () => {
-  it("returns null for missing dates", () => {
+  it("returns null for undefined dates", () => {
     expect(formatDate()).toBeNull();
-    expect(formatDate(null)).toBeNull();
     expect(formatDate(undefined)).toBeNull();
+  });
+
+  it("returns null for null and empty dates", () => {
+    expect(formatDate(null)).toBeNull();
     expect(formatDate("")).toBeNull();
+  });
+
+  it("returns null for an invalid date", () => {
+    expect(formatDate("not-a-date")).toBeNull();
+  });
+
+  it("returns null for an invalid locale", () => {
+    expect(formatDate("2024-01-15", { locale: "!!bad locale" })).toBeNull();
   });
 
   it("formats a valid date", () => {
@@ -23,9 +34,5 @@ describe("payload.utils.formatDate", () => {
 
     expect(formatted).toContain("January 15, 2024");
     expect(formatted).toMatch(/1:45/);
-  });
-
-  it("returns null when formatting throws", () => {
-    expect(formatDate("2024-01-15", { locale: "!!bad locale" })).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Defensive null-handling in the opportunities data path to avoid rendering errors when a record is missing a date or location.

## Changes

- **`payload/utils/formatDate.js`** — return `null` when no `date` is passed, instead of formatting `undefined` (which produces an "Invalid Date").
- **`lib/data/pagify/opportunities.js`** — fall back to `null` for a missing `doc.location` (`doc?.location ?? null`).

## screenshots
<img width="1116" height="416" alt="image" src="https://github.com/user-attachments/assets/3b1d3886-5f4a-448a-8687-030a13e9bc92" />

## Why

Opportunity overview content could be built from records without a `date`/`location`, surfacing an invalid date or throwing on an undefined field. These guards make both paths resilient.

## Testing

- `eslint` clean on changed files.