### PR TITLE
fix(trustlab): list loading progress + restore filter controls from URL

### DIFF
--- a/.changeset/fix-trustlab-list-filter-ux.md
+++ b/.changeset/fix-trustlab-list-filter-ux.md
@@ -1,0 +1,9 @@
+---
+"trustlab": patch
+---
+
+Improve the filterable list views (opportunities, reports, toolkits, playbooks):
+
+- Keep the current results in place while a filter/search/page change is fetching (no flash back to the unfiltered list), and show a progress indicator for user-driven fetches only — not on first load, tab focus, or reconnect.
+- Restore the filter controls (dropdowns/chips, sort, search) from bookmarked/shared URLs, and stop dropping other active filters on the first interaction.
+- Centralise list data-fetching in a shared `useListData` hook.

--- a/apps/trustlab/package.json
+++ b/apps/trustlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustlab",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/trustlab/src/components/Filters/Filters.js
+++ b/apps/trustlab/src/components/Filters/Filters.js
@@ -35,14 +35,15 @@ const defaultIcons = {
   report: DocumentIcon,
 };
 
-const generateYearOptions = () => {
+// Computed once at module load (year list is bounded 2020..current year), so we
+// don't re-run `new Date()` each time the filters config changes.
+const YEAR_OPTIONS = (() => {
   const currentYear = new Date().getFullYear();
   const len = currentYear - 2020 + 1;
   return Array.from({ length: len }, (_, i) => currentYear - i);
-};
+})();
 
-// Generate month options
-const generateMonthOptions = () => [
+const MONTH_OPTIONS = [
   { label: "January", value: 1 },
   { label: "February", value: 2 },
   { label: "March", value: 3 },
@@ -217,9 +218,9 @@ const Filters = React.forwardRef(function Filters(
       let resolvedOptions = options;
       if (!resolvedOptions?.length) {
         if (type === "year") {
-          resolvedOptions = generateYearOptions();
+          resolvedOptions = YEAR_OPTIONS;
         } else if (type === "month") {
-          resolvedOptions = generateMonthOptions();
+          resolvedOptions = MONTH_OPTIONS;
         }
       }
 

--- a/apps/trustlab/src/components/Filters/Filters.js
+++ b/apps/trustlab/src/components/Filters/Filters.js
@@ -1,22 +1,23 @@
 import {
   Box,
-  Typography,
   Button,
-  Stack,
   Chip,
-  SvgIcon,
-  InputBase,
   InputAdornment,
+  InputBase,
+  LinearProgress,
+  ListItemText,
   Menu,
   MenuItem,
-  ListItemText,
+  Stack,
+  SvgIcon,
+  Typography,
 } from "@mui/material";
 import React, {
-  useState,
-  useMemo,
   useCallback,
-  useRef,
   useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 
 import FilterDropdown from "./FilterDropdown";
@@ -160,7 +161,13 @@ const Filters = React.forwardRef(function Filters(
   {
     filterByLabel,
     filters = [],
+    // Current control state from the parent's URL-synced params: filter
+    // selections keyed by type, plus `sort` and `search`. Filters is controlled
+    // by this and holds no selection state of its own.
+    selectedValues = {},
+    defaultSort,
     clearFiltersLabel,
+    isBusy = false,
     onApply,
     onClear,
     sx,
@@ -173,13 +180,23 @@ const Filters = React.forwardRef(function Filters(
     onSortChange,
     // Atomic clear (preferred over onApply/onClear when search/sort are active)
     onClearAll,
+    showProgress = true,
+    // progress will take .5 height e.g. if showProgress = false, spacing should be 2.5
+    spacing = { xs: 2 },
   },
   ref,
 ) {
-  const [selectedValues, setSelectedValues] = useState({});
-  const [sortValue, setSortValue] = useState(null);
-  const [searchValue, setSearchValue] = useState("");
+  // Sort is controlled and the search box keeps a local draft for immediate
+  // typing while syncing from the current controlled state.
+  const sortValue = selectedValues.sort ?? null;
+  const hasActiveSort = Boolean(sortValue) && sortValue !== defaultSort;
+  const controlledSearchValue = selectedValues.search ?? "";
+  const [searchValue, setSearchValue] = useState(controlledSearchValue);
   const searchTimerRef = useRef(null);
+
+  useEffect(() => {
+    setSearchValue(controlledSearchValue);
+  }, [controlledSearchValue]);
 
   // Cleanup debounce timer on unmount
   useEffect(() => {
@@ -227,6 +244,27 @@ const Filters = React.forwardRef(function Filters(
     });
   }, [filters]);
 
+  // Reconcile the incoming selection (from the URL/params, where values are
+  // strings) against each filter's options so types match for selection
+  // highlighting and chip labels (e.g. year/month options are numbers).
+  const normalizedSelected = useMemo(() => {
+    const result = {};
+    processedFilters.forEach((filter) => {
+      const incoming = selectedValues?.[filter.type];
+      if (incoming == null) {
+        return;
+      }
+      const values = Array.isArray(incoming) ? incoming : [incoming];
+      result[filter.type] = values.map((value) => {
+        const option = filter.options.find(
+          (opt) => String(filter.getOptionValue(opt)) === String(value),
+        );
+        return option ? filter.getOptionValue(option) : value;
+      });
+    });
+    return result;
+  }, [selectedValues, processedFilters]);
+
   const getChipLabel = useCallback(
     (filterType, value) => {
       const filter = processedFilters.find((f) => f.type === filterType);
@@ -255,26 +293,20 @@ const Filters = React.forwardRef(function Filters(
 
   const handleFilterChange = useCallback(
     (filterType, values) => {
-      const newSelectedValues = {
-        ...selectedValues,
-        [filterType]: values,
-      };
-      setSelectedValues(newSelectedValues);
-
-      if (onApply) {
-        onApply(newSelectedValues);
-      }
+      // Controlled: emit the full selection and let the parent update
+      // params/URL, which flows back down as `selectedValues`.
+      onApply?.({ ...normalizedSelected, [filterType]: values });
     },
-    [selectedValues, onApply],
+    [normalizedSelected, onApply],
   );
 
   const handleChipDelete = useCallback(
     (filterType, value) => {
-      const currentValues = selectedValues[filterType] || [];
+      const currentValues = normalizedSelected[filterType] || [];
       const newValues = currentValues.filter((v) => v !== value);
       handleFilterChange(filterType, newValues);
     },
-    [selectedValues, handleFilterChange],
+    [normalizedSelected, handleFilterChange],
   );
 
   const handleSearchChange = useCallback(
@@ -293,15 +325,13 @@ const Filters = React.forwardRef(function Filters(
 
   const handleSortChange = useCallback(
     (value) => {
-      setSortValue(value);
+      // Controlled: let the parent update params/URL, which flows back as sortValue.
       onSortChange?.(value);
     },
     [onSortChange],
   );
 
   const clearAll = useCallback(() => {
-    setSelectedValues({});
-    setSortValue(null);
     setSearchValue("");
     if (searchTimerRef.current) {
       clearTimeout(searchTimerRef.current);
@@ -318,16 +348,16 @@ const Filters = React.forwardRef(function Filters(
 
   const anySelected = useMemo(() => {
     return (
-      Object.values(selectedValues).some((values) => values?.length > 0) ||
+      Object.values(normalizedSelected).some((values) => values?.length > 0) ||
       !!searchValue ||
-      !!sortValue
+      hasActiveSort
     );
-  }, [selectedValues, searchValue, sortValue]);
+  }, [normalizedSelected, searchValue, hasActiveSort]);
 
   // Collect all chips from all filter types
   const allChips = useMemo(() => {
     const chips = [];
-    Object.entries(selectedValues).forEach(([filterType, values]) => {
+    Object.entries(normalizedSelected).forEach(([filterType, values]) => {
       (values || []).forEach((value) => {
         chips.push({
           filterType,
@@ -337,7 +367,7 @@ const Filters = React.forwardRef(function Filters(
       });
     });
     return chips;
-  }, [selectedValues, getChipLabel]);
+  }, [normalizedSelected, getChipLabel]);
 
   // Gate on the callback props so a stale CMS label can't accidentally re-show
   // a control whose feature flag has been disabled
@@ -345,157 +375,164 @@ const Filters = React.forwardRef(function Filters(
   const showSort = Boolean(onSortChange) && sortOptions.length > 0;
 
   return (
-    <Box ref={ref} display="flex" flexDirection="column" gap={1} sx={sx}>
-      {/* Filter By label sits above the controls row */}
-      {filterByLabel && (
-        <Typography variant="subtitle1" fontWeight={700}>
-          {filterByLabel}
-        </Typography>
-      )}
+    <Stack spacing={spacing} sx={sx} ref={ref}>
+      <Box display="flex" flexDirection="column" gap={1}>
+        {/* Filter By label sits above the controls row */}
+        {filterByLabel && (
+          <Typography variant="subtitle1" fontWeight={700}>
+            {filterByLabel}
+          </Typography>
+        )}
 
-      {/* Controls row — flat flex row that wraps.
+        {/* Controls row — flat flex row that wraps.
           xs: search claims its own line (width 100%), filters + sort wrap below.
           sm+: search is capped at 50%, everything stays on one line. */}
-      <Stack
-        direction="row"
-        alignItems="center"
-        flexWrap="wrap"
-        useFlexGap
-        gap={2}
-      >
-        {showSearch && (
-          <InputBase
-            value={searchValue}
-            onChange={handleSearchChange}
-            placeholder={searchPlaceholderLabel || "Search..."}
-            startAdornment={
-              <InputAdornment position="start" sx={{ ml: 0.5, mr: 0.25 }}>
-                <SvgIcon
-                  sx={{ fontSize: 16, fill: "none", color: "text.secondary" }}
-                  viewBox="0 0 20 20"
-                >
-                  <circle
-                    cx="9"
-                    cy="9"
-                    r="6"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                  />
-                  <path
-                    d="m14 14 3.5 3.5"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                  />
-                </SvgIcon>
-              </InputAdornment>
-            }
-            sx={{
-              width: { xs: "100%", sm: "auto" },
-              flex: { sm: 1 },
-              maxWidth: { sm: "50%" },
-              minWidth: 180,
-              border: "1px solid #C9CACB",
-              borderRadius: "10px",
-              px: 1.5,
-              py: 0.5,
-              fontSize: "14px",
-              backgroundColor: "#fff",
-            }}
-          />
-        )}
-        {processedFilters.map((filter) => (
-          <FilterDropdown
-            key={filter.type}
-            label={filter.label}
-            options={filter.options}
-            selected={selectedValues[filter.type] || []}
-            onChange={(values) => handleFilterChange(filter.type, values)}
-            getOptionValue={filter.getOptionValue}
-            getOptionLabel={filter.getOptionLabel}
-            startIcon={
-              <SvgIcon
-                component={filter.icon}
-                sx={{ fill: "none", fontSize: "16px" }}
-              />
-            }
-            size="small"
-          />
-        ))}
-        {/* ml:auto keeps sort at the far right of whichever line it lands on */}
-        {showSort && (
-          <Box sx={{ ml: "auto" }}>
-            <SortDropdown
-              label={sortByLabel}
-              options={sortOptions}
-              value={sortValue}
-              onChange={handleSortChange}
-            />
-          </Box>
-        )}
-      </Stack>
-
-      {/* Row 3: Chips + Actions */}
-      <Stack
-        direction="row"
-        spacing={1}
-        flexWrap="wrap"
-        alignItems="center"
-        justifyContent="space-between"
-      >
-        <Box
-          display="flex"
+        <Stack
+          direction="row"
           alignItems="center"
           flexWrap="wrap"
+          useFlexGap
           gap={2}
-          flex={1}
         >
-          {allChips.map((chip) => (
-            <Chip
-              key={`${chip.filterType}-${chip.value}`}
-              label={chip.label}
-              size="small"
-              onDelete={() => handleChipDelete(chip.filterType, chip.value)}
+          {showSearch && (
+            <InputBase
+              value={searchValue}
+              onChange={handleSearchChange}
+              placeholder={searchPlaceholderLabel || "Search..."}
+              startAdornment={
+                <InputAdornment position="start" sx={{ ml: 0.5, mr: 0.25 }}>
+                  <SvgIcon
+                    sx={{ fontSize: 16, fill: "none", color: "text.secondary" }}
+                    viewBox="0 0 20 20"
+                  >
+                    <circle
+                      cx="9"
+                      cy="9"
+                      r="6"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                    />
+                    <path
+                      d="m14 14 3.5 3.5"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                    />
+                  </SvgIcon>
+                </InputAdornment>
+              }
               sx={{
-                px: 2,
+                width: { xs: "100%", sm: "auto" },
+                flex: { sm: 1 },
+                maxWidth: { sm: "50%" },
+                minWidth: 180,
+                border: "1px solid #C9CACB",
                 borderRadius: "10px",
-                p: 0.5,
+                px: 1.5,
+                py: 0.5,
+                fontSize: "14px",
+                backgroundColor: "#fff",
               }}
             />
-          ))}
-          {!!anySelected && (
-            <Button
-              variant="text"
-              onClick={clearAll}
-              size="small"
-              sx={{
-                textTransform: "none",
-                cursor: anySelected ? "pointer" : "default",
-                border: "none",
-                background: "transparent",
-                p: 0,
-                height: "20px",
-                color: "#BE1F23",
-                position: "relative",
-                pl: 3,
-              }}
-            >
-              <SvgIcon
-                sx={{
-                  fill: "none",
-                  position: "absolute",
-                  top: "50%",
-                  transform: "translateY(-35%)",
-                  left: 0,
-                }}
-                component={CloseIcon}
-              />
-              {clearFiltersLabel || "Clear Filter(s)"}
-            </Button>
           )}
+          {processedFilters.map((filter) => (
+            <FilterDropdown
+              key={filter.type}
+              label={filter.label}
+              options={filter.options}
+              selected={normalizedSelected[filter.type] || []}
+              onChange={(values) => handleFilterChange(filter.type, values)}
+              getOptionValue={filter.getOptionValue}
+              getOptionLabel={filter.getOptionLabel}
+              startIcon={
+                <SvgIcon
+                  component={filter.icon}
+                  sx={{ fill: "none", fontSize: "16px" }}
+                />
+              }
+              size="small"
+            />
+          ))}
+          {/* ml:auto keeps sort at the far right of whichever line it lands on */}
+          {showSort && (
+            <Box sx={{ ml: "auto" }}>
+              <SortDropdown
+                label={sortByLabel}
+                options={sortOptions}
+                value={sortValue}
+                onChange={handleSortChange}
+              />
+            </Box>
+          )}
+        </Stack>
+
+        {/* Row 3: Chips + Actions */}
+        <Stack
+          direction="row"
+          spacing={1}
+          flexWrap="wrap"
+          alignItems="center"
+          justifyContent="space-between"
+        >
+          <Box
+            display="flex"
+            alignItems="center"
+            flexWrap="wrap"
+            gap={2}
+            flex={1}
+          >
+            {allChips.map((chip) => (
+              <Chip
+                key={`${chip.filterType}-${chip.value}`}
+                label={chip.label}
+                size="small"
+                onDelete={() => handleChipDelete(chip.filterType, chip.value)}
+                sx={{
+                  px: 2,
+                  borderRadius: "10px",
+                  p: 0.5,
+                }}
+              />
+            ))}
+            {!!anySelected && (
+              <Button
+                variant="text"
+                onClick={clearAll}
+                size="small"
+                sx={{
+                  textTransform: "none",
+                  cursor: anySelected ? "pointer" : "default",
+                  border: "none",
+                  background: "transparent",
+                  p: 0,
+                  height: "20px",
+                  color: "#BE1F23",
+                  position: "relative",
+                  pl: 3,
+                }}
+              >
+                <SvgIcon
+                  sx={{
+                    fill: "none",
+                    position: "absolute",
+                    top: "50%",
+                    transform: "translateY(-35%)",
+                    left: 0,
+                  }}
+                  component={CloseIcon}
+                />
+                {clearFiltersLabel || "Clear Filter(s)"}
+              </Button>
+            )}
+          </Box>
+        </Stack>
+      </Box>
+      {showProgress ? (
+        <Box sx={{ height: 4, width: "100%" }}>
+          {isBusy ? <LinearProgress /> : null}
         </Box>
-      </Stack>
-    </Box>
+      ) : null}
+    </Stack>
   );
 });
 

--- a/apps/trustlab/src/components/Filters/Filters.snap.js
+++ b/apps/trustlab/src/components/Filters/Filters.snap.js
@@ -3,102 +3,109 @@
 exports[`ReportFilters renders unchanged 1`] = `
 <div>
   <div
-    class="MuiBox-root css-1821gv5"
+    class="MuiStack-root css-ook25x-MuiStack-root"
   >
-    <h6
-      class="MuiTypography-root MuiTypography-subtitle1 css-1k0y18v-MuiTypography-root"
-    >
-      Filter By
-    </h6>
     <div
-      class="MuiStack-root css-1u7tqyj-MuiStack-root"
+      class="MuiBox-root css-1821gv5"
     >
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
+      <h6
+        class="MuiTypography-root MuiTypography-subtitle1 css-1k0y18v-MuiTypography-root"
       >
-        <span
-          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
-            focusable="false"
-            viewbox="0 0 24 24"
-          />
-        </span>
-        Year
-        <span
-          class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
-            focusable="false"
-          />
-        </span>
-      </button>
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
-            focusable="false"
-            viewbox="0 0 24 24"
-          />
-        </span>
-        Month
-        <span
-          class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
-            focusable="false"
-          />
-        </span>
-      </button>
-      <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
-        tabindex="0"
-        type="button"
-      >
-        <span
-          class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
-            focusable="false"
-            viewbox="0 0 24 24"
-          />
-        </span>
-        Report
-        <span
-          class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
-        >
-          <div
-            aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
-            focusable="false"
-          />
-        </span>
-      </button>
-    </div>
-    <div
-      class="MuiStack-root css-1x34icn-MuiStack-root"
-    >
+        Filter By
+      </h6>
       <div
-        class="MuiBox-root css-1sl536g"
-      />
+        class="MuiStack-root css-1u7tqyj-MuiStack-root"
+      >
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
+              focusable="false"
+              viewbox="0 0 24 24"
+            />
+          </span>
+          Year
+          <span
+            class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
+              focusable="false"
+            />
+          </span>
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
+              focusable="false"
+              viewbox="0 0 24 24"
+            />
+          </span>
+          Month
+          <span
+            class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
+              focusable="false"
+            />
+          </span>
+        </button>
+        <button
+          class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-impya7-MuiButtonBase-root-MuiButton-root"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="MuiButton-icon MuiButton-startIcon MuiButton-iconSizeSmall css-1in3o51-MuiButton-startIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-129mfkz-MuiSvgIcon-root"
+              focusable="false"
+              viewbox="0 0 24 24"
+            />
+          </span>
+          Report
+          <span
+            class="MuiButton-icon MuiButton-endIcon MuiButton-iconSizeSmall css-dp0v3c-MuiButton-endIcon"
+          >
+            <div
+              aria-hidden="true"
+              class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1it0eoq-MuiSvgIcon-root"
+              focusable="false"
+            />
+          </span>
+        </button>
+      </div>
+      <div
+        class="MuiStack-root css-1x34icn-MuiStack-root"
+      >
+        <div
+          class="MuiBox-root css-1sl536g"
+        />
+      </div>
     </div>
+    <div
+      class="MuiBox-root css-xh7cac"
+    />
   </div>
 </div>
 `;

--- a/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
+++ b/apps/trustlab/src/components/OpportunitiesList/OpportunitiesList.js
@@ -96,7 +96,11 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     setParams(newParams);
   }, [router.isReady]);
 
-  const { items = [], pagination = p } = useOpportunities(
+  const {
+    items = [],
+    pagination = p,
+    isBusy,
+  } = useOpportunities(
     page,
     params,
     initialItems,
@@ -223,12 +227,14 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
     }
     router.push(urlPath, undefined, { shallow: true, scroll: false });
   }
+  const showTitle = title || description;
+  const showFilterBar = hasFilters || hasSearch || hasSortBy;
   return (
     <Box
       ref={listRef}
       sx={{ background: backgroundColor, color: textColor, ...sx }}
     >
-      {title || description ? (
+      {showTitle ? (
         <Section sx={{ pt: 5, pb: 0, px: { xs: 2.5, md: 0 } }}>
           <Typography variant="h2">{title}</Typography>
           {description && (
@@ -252,13 +258,17 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
         </Section>
       ) : null}
 
-      {hasFilters || hasSearch || hasSortBy ? (
-        <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
+      {showFilterBar ? (
+        // pb is 2 instead of 2.5 because of progress bar taking .5 i.e. 4px
+        <Section sx={{ pt: 2.5, pb: 2, px: { xs: 2.5, sm: 0 } }}>
           <Filters
-            filterByLabel={filterByLabel}
-            filters={filters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}
+            filterByLabel={filterByLabel}
+            filters={filters}
+            selectedValues={params}
+            defaultSort={defaultSort}
+            isBusy={isBusy}
             onApply={handleApplyFilters}
             onClearAll={handleClearAll}
             onSearch={hasSearch ? handleSearch : undefined}
@@ -276,7 +286,7 @@ const OpportunitiesList = forwardRef(function OpportunitiesList(props, ref) {
         <Section
           sx={{
             pb: 5,
-            pt: title || description ? 0 : 5,
+            pt: showTitle ? 0 : 5,
             px: { xs: 2.5, sm: 0 },
           }}
         >

--- a/apps/trustlab/src/components/OpportunitiesList/useOpportunities.js
+++ b/apps/trustlab/src/components/OpportunitiesList/useOpportunities.js
@@ -1,8 +1,5 @@
-import useSWR from "swr";
-
+import useListData from "@/trustlab/hooks/useListData";
 import { setSearchParam } from "@/trustlab/utils/queryParams";
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
 
 // Allowlist of params forwarded to the API. Intentionally excludes `page`
 // (set separately) and keeps arbitrary URL params from being proxied through.
@@ -34,14 +31,17 @@ function useOpportunities(
     setSearchParam(searchParams, key, params?.[key]);
   });
 
-  const { data } = useSWR(
-    skip ? null : `${apiEndpoint}?${searchParams.toString()}`,
-    fetcher,
-    { fallbackData: { docs: initialItems, page, totalPages: initialCount } },
+  const { data, isBusy } = useListData(
+    `${apiEndpoint}?${searchParams.toString()}`,
+    {
+      fallbackData: { docs: initialItems, page, totalPages: initialCount },
+      enabled: !skip,
+    },
   );
 
   return {
     items: skip ? initialItems : (data?.docs ?? initialItems),
+    isBusy,
     pagination: {
       page: data?.page ?? page,
       count: data?.totalPages ?? initialCount,

--- a/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
+++ b/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
@@ -57,13 +57,11 @@ const PlaybooksList = forwardRef(function PlaybooksList(props, ref) {
     }));
   }, [router.isReady]);
 
-  const { playbooks = [], pagination = p } = usePlaybooks(
-    page,
-    params,
-    initialPlaybooks,
-    p?.count,
-    !hasPagination,
-  );
+  const {
+    playbooks = [],
+    pagination = p,
+    isBusy,
+  } = usePlaybooks(page, params, initialPlaybooks, p?.count, !hasPagination);
 
   const handlePageChange = (value) => {
     setPage(value);
@@ -107,10 +105,12 @@ const PlaybooksList = forwardRef(function PlaybooksList(props, ref) {
       ref={ref}
     >
       {hasFilters ? (
-        <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
+        <Section sx={{ pt: 2.5, pb: 2, px: { xs: 2.5, sm: 0 } }}>
           <Filters
             filters={filters}
             filterByLabel={filterByLabel}
+            selectedValues={params}
+            isBusy={isBusy}
             hasFilters={hasFilters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}

--- a/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
+++ b/apps/trustlab/src/components/PlaybooksList/PlaybooksList.js
@@ -111,7 +111,6 @@ const PlaybooksList = forwardRef(function PlaybooksList(props, ref) {
             filterByLabel={filterByLabel}
             selectedValues={params}
             isBusy={isBusy}
-            hasFilters={hasFilters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}
             onApply={handleApplyFilters}

--- a/apps/trustlab/src/components/PlaybooksList/usePlaybooks.js
+++ b/apps/trustlab/src/components/PlaybooksList/usePlaybooks.js
@@ -1,16 +1,5 @@
-import useSWR from "swr";
-
-import { setSearchParam } from "@/trustlab/utils/queryParams";
-
-export const buildQueryString = (params) => {
-  const query = new URLSearchParams();
-  Object.entries(params || {}).forEach(([key, value]) => {
-    setSearchParam(query, key, value);
-  });
-  return query.toString();
-};
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
+import useListData from "@/trustlab/hooks/useListData";
+import { buildQueryString } from "@/trustlab/utils/queryParams";
 
 const usePlaybooks = (
   page,
@@ -20,23 +9,20 @@ const usePlaybooks = (
   showAllPosts,
 ) => {
   const queryString = buildQueryString({ ...params, page });
-  const { data, isLoading } = useSWR(
-    `/api/v1/playbooks?${queryString}`,
-    fetcher,
-  );
+  const { data, isBusy } = useListData(`/api/v1/playbooks?${queryString}`);
 
   if (!data) {
     return {
       playbooks: initialPlaybooks || [],
       pagination: { count: initialCount, page },
-      isLoading: true,
+      isBusy,
     };
   }
 
   return {
     playbooks: !showAllPosts ? data?.playbooks || [] : initialPlaybooks || [],
     pagination: data?.pagination,
-    isLoading,
+    isBusy,
   };
 };
 

--- a/apps/trustlab/src/components/ReportsList/ReportsList.js
+++ b/apps/trustlab/src/components/ReportsList/ReportsList.js
@@ -44,17 +44,27 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     defaultSort,
   } = props;
 
-  const [page, setPage] = useState(p?.page);
-  const [params, setParams] = useState({
-    reportsType,
-    limit: reportsPerPage,
-    ...(defaultSort ? { sort: defaultSort } : {}),
-  });
-  const listRef = useRef(null);
-  useImperativeHandle(ref, () => listRef.current);
   const router = useRouter();
   const { query } = router;
   const { page: initialPage } = query;
+
+  const [page, setPage] = useState(p?.page);
+  const [params, setParams] = useState(() => ({
+    reportsType,
+    limit: reportsPerPage,
+    ...(defaultSort ? { sort: defaultSort } : {}),
+    // Restore filters from the URL at mount (mirrors the router.isReady effect
+    // below) so client-side nav to a filtered URL renders without a flash.
+    ...parseQueryParams({
+      year: query.year,
+      month: query.month,
+      report: query.report,
+      sort: query.sort,
+      search: query.search,
+    }),
+  }));
+  const listRef = useRef(null);
+  useImperativeHandle(ref, () => listRef.current);
 
   useEffect(() => {
     if (initialPage) {

--- a/apps/trustlab/src/components/ReportsList/ReportsList.js
+++ b/apps/trustlab/src/components/ReportsList/ReportsList.js
@@ -65,7 +65,11 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
     }
   }, [initialPage]);
 
-  const { reports = [], pagination = p } = useReports(
+  const {
+    reports = [],
+    pagination = p,
+    isBusy,
+  } = useReports(
     page,
     params,
     initialReports,
@@ -222,10 +226,13 @@ const ReportsList = forwardRef(function ReportsList(props, ref) {
   return (
     <Box ref={listRef}>
       {showFiltersBar ? (
-        <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
+        <Section sx={{ pt: 2.5, pb: 0, px: { xs: 2.5, sm: 0 } }}>
           <Filters
             filterByLabel={filterByLabel}
             filters={filters}
+            selectedValues={params}
+            defaultSort={defaultSort}
+            isBusy={isBusy}
             clearFiltersLabel={clearFiltersLabel}
             applyFiltersLabel={applyFiltersLabel}
             onApply={handleApplyFilters}

--- a/apps/trustlab/src/components/ReportsList/useReports.js
+++ b/apps/trustlab/src/components/ReportsList/useReports.js
@@ -1,8 +1,5 @@
-import useSWR from "swr";
-
+import useListData from "@/trustlab/hooks/useListData";
 import { setSearchParam } from "@/trustlab/utils/queryParams";
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
 
 // Allowlist of params forwarded to the API. Intentionally excludes `page`
 // (set separately) and keeps arbitrary URL params from being proxied through.
@@ -25,16 +22,17 @@ function useReports(page, params, initialReports, initialCount, skip) {
     setSearchParam(searchParams, key, params?.[key]);
   });
 
-  const { data } = useSWR(
-    skip ? null : `/api/v1/reports?${searchParams.toString()}`,
-    fetcher,
+  const { data, isBusy } = useListData(
+    `/api/v1/reports?${searchParams.toString()}`,
     {
       fallbackData: { reports: initialReports, page, totalPages: initialCount },
+      enabled: !skip,
     },
   );
 
   return {
     reports: skip ? initialReports : (data?.reports ?? initialReports),
+    isBusy,
     pagination: {
       page: data?.pagination?.page ?? page,
       count: data?.pagination?.count ?? initialCount,

--- a/apps/trustlab/src/components/ToolkitList/ToolkitList.js
+++ b/apps/trustlab/src/components/ToolkitList/ToolkitList.js
@@ -60,13 +60,11 @@ const ToolkitList = forwardRef(function ToolkitList(props, ref) {
     }));
   }, [router.isReady]);
 
-  const { toolkits = [], pagination = p } = useToolkits(
-    page,
-    params,
-    initialToolkits,
-    p?.count,
-    !hasPagination,
-  );
+  const {
+    toolkits = [],
+    pagination = p,
+    isBusy,
+  } = useToolkits(page, params, initialToolkits, p?.count, !hasPagination);
 
   const handlePageChange = (value) => {
     setPage(value);
@@ -104,10 +102,12 @@ const ToolkitList = forwardRef(function ToolkitList(props, ref) {
   return (
     <Box sx={sx} ref={ref}>
       {hasFilters && (
-        <Section sx={{ py: 2.5, px: { xs: 2.5, sm: 0 } }}>
+        <Section sx={{ pt: 2.5, pb: 2, px: { xs: 2.5, sm: 0 } }}>
           <Filters
             filters={filters}
             filterByLabel={filterByLabel}
+            selectedValues={params}
+            isBusy={isBusy}
             hasFilters={hasFilters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}

--- a/apps/trustlab/src/components/ToolkitList/ToolkitList.js
+++ b/apps/trustlab/src/components/ToolkitList/ToolkitList.js
@@ -108,7 +108,6 @@ const ToolkitList = forwardRef(function ToolkitList(props, ref) {
             filterByLabel={filterByLabel}
             selectedValues={params}
             isBusy={isBusy}
-            hasFilters={hasFilters}
             applyFiltersLabel={applyFiltersLabel}
             clearFiltersLabel={clearFiltersLabel}
             onApply={handleApplyFilters}

--- a/apps/trustlab/src/components/ToolkitList/useToolkits.js
+++ b/apps/trustlab/src/components/ToolkitList/useToolkits.js
@@ -1,35 +1,23 @@
-import useSWR from "swr";
-
-import { setSearchParam } from "@/trustlab/utils/queryParams";
-
-export const buildQueryString = (params) => {
-  const query = new URLSearchParams();
-  Object.entries(params || {}).forEach(([key, value]) => {
-    setSearchParam(query, key, value);
-  });
-  return query.toString();
-};
-
-const fetcher = (url) => fetch(url).then((res) => res.json());
+import useListData from "@/trustlab/hooks/useListData";
+import { buildQueryString } from "@/trustlab/utils/queryParams";
 
 const useToolkits = (page, params, initialToolkits, _, showAll) => {
   const queryString = buildQueryString({ ...params, page });
-  const { data, isLoading } = useSWR(
-    `/api/v1/toolkits?${queryString}`,
-    fetcher,
-  );
+  const { data, isBusy } = useListData(`/api/v1/toolkits?${queryString}`, {
+    enabled: !showAll,
+  });
   if (!data?.toolkits || showAll) {
     return {
       toolkits: initialToolkits || [],
       pagination: { count: 1, page: 1 },
-      isLoading: true,
+      isBusy,
     };
   }
 
   return {
     toolkits: !showAll ? data?.toolkits || [] : initialToolkits || [],
     pagination: data?.pagination,
-    isLoading,
+    isBusy,
   };
 };
 

--- a/apps/trustlab/src/components/ToolkitList/useToolkits.js
+++ b/apps/trustlab/src/components/ToolkitList/useToolkits.js
@@ -15,7 +15,7 @@ const useToolkits = (page, params, initialToolkits, _, showAll) => {
   }
 
   return {
-    toolkits: !showAll ? data?.toolkits || [] : initialToolkits || [],
+    toolkits: data?.toolkits || [],
     pagination: data?.pagination,
     isBusy,
   };

--- a/apps/trustlab/src/hooks/useListData.js
+++ b/apps/trustlab/src/hooks/useListData.js
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import useSWR from "swr";
+
+const fetcher = (url) => fetch(url).then((res) => res.json());
+
+// Sensible defaults for the filterable list views (opportunities, reports,
+// toolkits, playbooks) — callers may override any of them. By default:
+//  - keepPreviousData: hold the current results in place during a refetch so
+//    the list never flashes back to the unfiltered set.
+//  - no focus/reconnect revalidation.
+// Mount revalidation stays ON so ISR-stale pages refresh on load. `isBusy`
+// reflects only fetches for a NEW key (the user changed the query); revalidating
+// the current key (mount/background freshness) stays silent — SWR's isLoading
+// can't make this distinction because it tracks cache presence, not whether the
+// fetched key differs from the one on screen (and on mount we show fallback).
+// Extra options (e.g. fallbackData) pass through to useSWR; `enabled` mirrors
+// each list's skip flag.
+export default function useListData(url, { enabled = true, ...options } = {}) {
+  const key = enabled ? url : null;
+  const { data, isValidating } = useSWR(key, fetcher, {
+    keepPreviousData: true,
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+    ...options,
+  });
+
+  // Track the key whose data is currently on screen; we're "busy" only while
+  // fetching a different key, not while revalidating the current one.
+  const shownKey = useRef(key);
+  useEffect(() => {
+    if (!isValidating) {
+      shownKey.current = key;
+    }
+  }, [isValidating, key]);
+
+  return {
+    data,
+    isBusy: Boolean(key) && isValidating && shownKey.current !== key,
+  };
+}

--- a/apps/trustlab/src/utils/queryParams.js
+++ b/apps/trustlab/src/utils/queryParams.js
@@ -43,3 +43,13 @@ export function setSearchParam(searchParams, key, value) {
   searchParams.delete(key);
   normalizeQueryList(value).forEach((v) => searchParams.append(key, v));
 }
+
+// Serialize a params object into a query string, applying setSearchParam per
+// key (repeated params for arrays, trimmed, blanks dropped).
+export function buildQueryString(params) {
+  const searchParams = new URLSearchParams();
+  Object.entries(params || {}).forEach(([key, value]) => {
+    setSearchParam(searchParams, key, value);
+  });
+  return searchParams.toString();
+}


### PR DESCRIPTION
## Description

### What & why

Follow-up to the list-filter fixes (#1493). Improves the UX of the filterable list views — opportunities, reports, toolkits, playbooks — and centralises their data-fetching.

Three problems addressed:
1. **Stale-data flash** — applying a filter momentarily showed the *unfiltered* list before the filtered results arrived.
2. **No loading feedback / flicker** — no indication a query was in flight, and a naive indicator flickered on tab focus and first load.
3. **Filter controls didn't reflect the URL** — a bookmarked `?year=…&sort=…&search=…` filtered the results but the dropdowns/chips/sort/search showed nothing, and changing one filter dropped the others.

### Changes

**`refactor: centralise list data-fetching in a useListData hook`**
- New `useListData` (in `src/hooks/`): one place for the SWR policy — `keepPreviousData`, no focus/reconnect revalidation, and `isBusy` that fires **only for new-key (user-driven) fetches**, not mount/background revalidation (so progress never shows on first load while ISR freshness still revalidates silently).
- Shared `buildQueryString` moved into `queryParams`; the four list hooks adopt `useListData` and drop their duplicated `fetcher`/`buildQueryString`.

**`fix: show list loading progress and restore filter controls from URL`**
- A thin `LinearProgress` in the shared `Filters` bar shows while a new query is fetching; `keepPreviousData` holds the current results in place (no flash).
- `Filters` is now **controlled** by the parent's URL-synced `params`: filter dropdowns/chips, **sort**, and **search** all restore from a bookmarked URL. Fixes filters being dropped on first interaction. `defaultSort` is treated as "not a user selection" for the clear-state.

### Verification
- `pnpm jest --filter=trustlab` — 177 passing
- `pnpm lint:check` / `pnpm format:check` — clean
- `pnpm --filter=trustlab build` (next build) — compiles; pages-router routes intact; no phantom `*.test` routes
- Behaviour spot-checked in the running app (filter/search/sort, bookmarked URLs, tab-switch, first load)

### Known follow-ups
- Search input stays internal+debounced (synced from the controlled value); deliberate, not fully controlled.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Screenshots

<img width="1252" height="727" alt="Screenshot 2026-06-29 at 08 59 47" src="https://github.com/user-attachments/assets/2b5d6256-a08b-427f-b5f4-611d569b4270" />

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
