### PR TITLE
perf(trustlab): preload Airtable form embeds so dialogs open instantly

### DIFF
--- a/.changeset/trustlab-airtable-embed-preload.md
+++ b/.changeset/trustlab-airtable-embed-preload.md
@@ -1,0 +1,11 @@
+---
+"trustlab": patch
+---
+
+Speed up Airtable form embeds so dialogs open instantly:
+
+- Preload embeds in the background once the browser is idle after page load, instead of waiting for the button click.
+- Show a loading skeleton in the embed dialog until the form is ready, instead of a blank area.
+- Add `preconnect`/`dns-prefetch` hints for Airtable domains.
+- Keep dialogs mounted after closing so reopening a form is instant.
+- Render embeds as a controlled iframe (shared `AirtableEmbed` component) instead of injecting raw HTML, decoding HTML entities in the extracted `src`.

--- a/apps/trustlab/package.json
+++ b/apps/trustlab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trustlab",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/trustlab/src/components/ActionBanner/ActionBanner.js
+++ b/apps/trustlab/src/components/ActionBanner/ActionBanner.js
@@ -12,6 +12,8 @@ import {
 import React, { forwardRef, useState } from "react";
 
 import CloseIcon from "@/trustlab/assets/icons/close.svg";
+import AirtableEmbed from "@/trustlab/components/AirtableEmbed";
+import useAirtableEmbedPreload from "@/trustlab/components/AirtableEmbed/useAirtableEmbedPreload";
 import Button from "@/trustlab/components/StyledButton";
 
 const ActionBanner = forwardRef(function ActionBanner(
@@ -30,6 +32,7 @@ const ActionBanner = forwardRef(function ActionBanner(
 ) {
   const hasEmbed = Boolean(embedCode?.trim());
   const [open, setOpen] = useState(false);
+  const preload = useAirtableEmbedPreload(hasEmbed);
 
   const handleOpen = () => {
     if (hasEmbed) {
@@ -116,6 +119,7 @@ const ActionBanner = forwardRef(function ActionBanner(
         <Dialog
           open={open}
           onClose={handleClose}
+          keepMounted
           maxWidth="md"
           fullWidth
           PaperProps={{
@@ -144,15 +148,12 @@ const ActionBanner = forwardRef(function ActionBanner(
             </IconButton>
           </DialogTitle>
           <DialogContent>
-            <Box
-              dangerouslySetInnerHTML={{ __html: embedCode }}
+            <AirtableEmbed
+              embedCode={embedCode}
+              load={Boolean(preload || open)}
+              title={embedDialogTitle}
               sx={{
-                width: "100%",
-                "& iframe": {
-                  width: "100%",
-                  minHeight: 400,
-                  border: "none",
-                },
+                height: { xs: 450, md: "70vh" },
               }}
             />
           </DialogContent>

--- a/apps/trustlab/src/components/AirtableEmbed/AirtableEmbed.js
+++ b/apps/trustlab/src/components/AirtableEmbed/AirtableEmbed.js
@@ -1,9 +1,26 @@
 import { Box, Skeleton } from "@mui/material";
 import React, { useMemo, useState } from "react";
 
+const HTML_ENTITIES = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#39;": "'",
+};
+
+// Attribute values in pasted embed code are HTML-escaped (e.g. `&` appears
+// as `&amp;` between query params); the browser would decode them when
+// parsing HTML, so we must too before reusing the URL as an iframe src.
+function decodeHtmlEntities(value) {
+  return value.replace(/&(?:amp|lt|gt|quot|#39);/g, (entity) => {
+    return HTML_ENTITIES[entity];
+  });
+}
+
 function extractIframeSrc(embedCode) {
   const match = embedCode?.match(/<iframe[^>]*\ssrc=["']([^"']+)["']/i);
-  return match?.[1] ?? null;
+  return match?.[1] ? decodeHtmlEntities(match[1]) : null;
 }
 
 function AirtableEmbed({ embedCode, load = true, title, sx }) {

--- a/apps/trustlab/src/components/AirtableEmbed/AirtableEmbed.js
+++ b/apps/trustlab/src/components/AirtableEmbed/AirtableEmbed.js
@@ -1,0 +1,78 @@
+import { Box, Skeleton } from "@mui/material";
+import React, { useMemo, useState } from "react";
+
+function extractIframeSrc(embedCode) {
+  const match = embedCode?.match(/<iframe[^>]*\ssrc=["']([^"']+)["']/i);
+  return match?.[1] ?? null;
+}
+
+function AirtableEmbed({ embedCode, load = true, title, sx }) {
+  const src = useMemo(() => extractIframeSrc(embedCode), [embedCode]);
+  const [loaded, setLoaded] = useState(false);
+
+  if (!embedCode?.trim()) {
+    return null;
+  }
+  if (!src) {
+    // Embed code without a parseable iframe src; inject as-is
+    if (!load) {
+      return null;
+    }
+    return (
+      <Box
+        sx={[
+          {
+            width: "100%",
+            "& iframe": {
+              width: "100%",
+              height: "100%",
+              border: 0,
+            },
+          },
+          ...(Array.isArray(sx) ? sx : [sx]),
+        ]}
+        dangerouslySetInnerHTML={{ __html: embedCode }}
+      />
+    );
+  }
+  return (
+    <Box
+      sx={[
+        { position: "relative", width: "100%" },
+        ...(Array.isArray(sx) ? sx : [sx]),
+      ]}
+    >
+      {!loaded && (
+        <Skeleton
+          variant="rectangular"
+          sx={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+          }}
+        />
+      )}
+      {load && (
+        <Box
+          component="iframe"
+          src={src}
+          title={title || "Airtable form"}
+          onLoad={() => setLoaded(true)}
+          sx={{
+            position: "absolute",
+            inset: 0,
+            width: "100%",
+            height: "100%",
+            border: 0,
+            display: "block",
+            opacity: loaded ? 1 : 0,
+            transition: "opacity 0.2s ease-in",
+          }}
+        />
+      )}
+    </Box>
+  );
+}
+
+export default AirtableEmbed;

--- a/apps/trustlab/src/components/AirtableEmbed/index.js
+++ b/apps/trustlab/src/components/AirtableEmbed/index.js
@@ -1,0 +1,3 @@
+import AirtableEmbed from "./AirtableEmbed";
+
+export default AirtableEmbed;

--- a/apps/trustlab/src/components/AirtableEmbed/useAirtableEmbedPreload.js
+++ b/apps/trustlab/src/components/AirtableEmbed/useAirtableEmbedPreload.js
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+
+// Preload the embed once the browser is idle after mount so the form is
+// already (mostly) loaded by the time the user opens the dialog, without
+// competing with the page's own initial load.
+function useAirtableEmbedPreload(enabled) {
+  const [preload, setPreload] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || preload) {
+      return undefined;
+    }
+    if (typeof window.requestIdleCallback === "function") {
+      const id = window.requestIdleCallback(() => setPreload(true), {
+        timeout: 2000,
+      });
+      return () => window.cancelIdleCallback(id);
+    }
+    // Safari has no requestIdleCallback
+    const id = window.setTimeout(() => setPreload(true), 500);
+    return () => window.clearTimeout(id);
+  }, [enabled, preload]);
+
+  return preload;
+}
+
+export default useAirtableEmbedPreload;

--- a/apps/trustlab/src/components/HelplineCard/HelplineCard.js
+++ b/apps/trustlab/src/components/HelplineCard/HelplineCard.js
@@ -14,6 +14,8 @@ import React, { useState } from "react";
 
 import HelplineEmbedDialog from "./HelplineEmbedDialog";
 
+import useAirtableEmbedPreload from "@/trustlab/components/AirtableEmbed/useAirtableEmbedPreload";
+
 function HelplineCard({
   title,
   icon: media,
@@ -25,6 +27,7 @@ function HelplineCard({
 }) {
   const hasEmbed = Boolean(embedCode?.trim());
   const [open, setOpen] = useState(false);
+  const preload = useAirtableEmbedPreload(hasEmbed);
   const buttonLabel = embedButtonLabel || link?.label || title;
 
   const handleOpen = () => {
@@ -122,13 +125,16 @@ function HelplineCard({
           </Button>
         )}
       </CardActions>
-      <HelplineEmbedDialog
-        closeLabel={embedCloseLabel}
-        embedCode={embedCode}
-        onClose={handleClose}
-        open={open}
-        title={title}
-      />
+      {hasEmbed && (
+        <HelplineEmbedDialog
+          closeLabel={embedCloseLabel}
+          embedCode={embedCode}
+          onClose={handleClose}
+          open={open}
+          preload={preload}
+          title={title}
+        />
+      )}
     </Card>
   );
 }

--- a/apps/trustlab/src/components/HelplineCard/HelplineEmbedDialog.js
+++ b/apps/trustlab/src/components/HelplineCard/HelplineEmbedDialog.js
@@ -1,5 +1,4 @@
 import {
-  Box,
   Button,
   Dialog,
   DialogActions,
@@ -8,13 +7,23 @@ import {
 } from "@mui/material";
 import React from "react";
 
-function HelplineEmbedDialog({ closeLabel, embedCode, onClose, open, title }) {
+import AirtableEmbed from "@/trustlab/components/AirtableEmbed";
+
+function HelplineEmbedDialog({
+  closeLabel,
+  embedCode,
+  onClose,
+  open,
+  preload,
+  title,
+}) {
   const dialogTitleId = React.useId();
 
   return (
     <Dialog
       aria-labelledby={dialogTitleId}
       fullWidth
+      keepMounted
       maxWidth={false}
       onClose={onClose}
       open={Boolean(open)}
@@ -31,28 +40,15 @@ function HelplineEmbedDialog({ closeLabel, embedCode, onClose, open, title }) {
         dividers
         sx={{
           p: 0,
-          "& .airtable-embed-container": {
-            width: "100%",
-            height: "100%",
-          },
         }}
       >
-        <Box
-          className="airtable-embed-container"
+        <AirtableEmbed
+          embedCode={embedCode}
+          load={Boolean(preload || open)}
+          title={title}
           sx={{
-            width: "100%",
-            "& iframe": {
-              width: "100%",
-              minHeight: { xs: 400, md: "70vh" },
-            },
+            height: { xs: 400, md: "70vh" },
           }}
-          dangerouslySetInnerHTML={
-            embedCode?.trim()
-              ? {
-                  __html: embedCode,
-                }
-              : undefined
-          }
         />
       </DialogContent>
       <DialogActions sx={{ px: 3, py: 2 }}>

--- a/apps/trustlab/src/components/RowCard/RowCard.js
+++ b/apps/trustlab/src/components/RowCard/RowCard.js
@@ -4,6 +4,7 @@ import { useState, forwardRef } from "react";
 
 import RowCardActionButton from "./RowCardActionButton";
 
+import useAirtableEmbedPreload from "@/trustlab/components/AirtableEmbed/useAirtableEmbedPreload";
 import HelplineEmbedDialog from "@/trustlab/components/HelplineCard/HelplineEmbedDialog";
 
 const RowCard = forwardRef(function RowCard(props, ref) {
@@ -20,6 +21,7 @@ const RowCard = forwardRef(function RowCard(props, ref) {
   } = props;
   const hasEmbed = Boolean(embedCode?.trim());
   const [open, setOpen] = useState(false);
+  const preload = useAirtableEmbedPreload(hasEmbed);
   const buttonLabel = embedButtonLabel || actionLabel;
 
   const handleOpen = () => {
@@ -107,13 +109,16 @@ const RowCard = forwardRef(function RowCard(props, ref) {
           onOpen={handleOpen}
         />
       </Stack>
-      <HelplineEmbedDialog
-        closeLabel={embedCloseLabel}
-        embedCode={embedCode}
-        onClose={handleClose}
-        open={open}
-        title={title}
-      />
+      {hasEmbed && (
+        <HelplineEmbedDialog
+          closeLabel={embedCloseLabel}
+          embedCode={embedCode}
+          onClose={handleClose}
+          open={open}
+          preload={preload}
+          title={title}
+        />
+      )}
     </Card>
   );
 });

--- a/apps/trustlab/src/pages/_document.page.js
+++ b/apps/trustlab/src/pages/_document.page.js
@@ -55,6 +55,9 @@ class MyDocument extends Document {
             href="/apple-touch-icon.png"
           />
           <link rel="manifest" href="/site.webmanifest" />
+          <link rel="preconnect" href="https://airtable.com" />
+          <link rel="dns-prefetch" href="https://airtable.com" />
+          <link rel="dns-prefetch" href="https://static.airtable.com" />
           <meta name="apple-mobile-web-app-title" content="TrustLab" />
           <meta name="theme-color" content="#000" />
           <meta name="emotion-insertion-point" content="" />


### PR DESCRIPTION
## Description

Airtable form embeds across TrustLab pages (helpline cards, row cards, and action banners) only started loading when a user clicked the button to open the dialog. Since an Airtable embed boots the entire Airtable app inside an iframe, users stared at a blank dialog for several seconds before the form appeared.

## Changes

- **Preload on page load** — embeds now start loading in the background once the browser is idle after the page renders, so the form is typically ready before the user clicks. Loading is deferred to idle time so it doesn't compete with the page's own initial load.
- **Loading skeleton** — the embed dialog shows a skeleton until the iframe finishes loading, instead of a blank white area, with the form fading in once ready.
- **Warm connections** — added `preconnect`/`dns-prefetch` hints for Airtable domains to shave DNS/TLS handshake time off the first request.
- **Keep embeds alive** — dialogs stay mounted after closing, so reopening a form is instant instead of reloading it from scratch.
- The embed markup is now parsed and rendered as a controlled iframe (shared component) rather than injected as raw HTML.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
