### PR TITLE
fix(pesayetu): preserve cached explore pages when HURUmap fails

### DIFF
--- a/apps/pesayetu/package.json
+++ b/apps/pesayetu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pesayetu",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "private": true,
   "author": "Code for Africa <tech@codeforafrica.org>",
   "description": "PesaYetu helps journalists, researchers and activists transform their work with in-depth county-specific information. Get started now with datasets from Kenya.",

--- a/apps/pesayetu/src/lib/hurumap/index.js
+++ b/apps/pesayetu/src/lib/hurumap/index.js
@@ -10,11 +10,16 @@ export async function fetchProfile() {
     new URL("/api/v1/profiles/1/?format=json", apiUrl),
   );
 
-  const locations = configuration?.featured_locations?.map(
-    ({ name, code, level }) => {
-      return { name, level, code: code.toLowerCase() };
-    },
-  );
+  const featuredLocations = configuration?.featured_locations;
+  if (!Array.isArray(featuredLocations) || !featuredLocations.length) {
+    throw new Error(
+      "Invalid HURUmap profile response: featured_locations is missing or empty",
+    );
+  }
+
+  const locations = featuredLocations.map(({ name, code, level }) => {
+    return { name, level, code: code.toLowerCase() };
+  });
 
   return { locations, preferredChildren: configuration.preferred_children };
 }

--- a/apps/pesayetu/src/lib/hurumap/index.test.js
+++ b/apps/pesayetu/src/lib/hurumap/index.test.js
@@ -1,0 +1,72 @@
+import { fetchProfile } from "@/pesayetu/lib/hurumap";
+
+describe("fetchProfile", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = undefined;
+  });
+
+  it("throws when HURUmap responds with an HTTP error", async () => {
+    global.fetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: "Service Unavailable",
+      json: jest.fn(),
+    });
+
+    await expect(fetchProfile()).rejects.toThrow(
+      "failed with status 503 Service Unavailable",
+    );
+  });
+
+  it("throws when HURUmap returns an empty location configuration", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        configuration: {
+          featured_locations: [],
+        },
+      }),
+    });
+
+    await expect(fetchProfile()).rejects.toThrow(
+      "Invalid HURUmap profile response",
+    );
+  });
+
+  it("normalizes location codes from a valid profile", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue({
+        configuration: {
+          featured_locations: [
+            {
+              code: "KE",
+              level: "country",
+              name: "Kenya",
+            },
+          ],
+          preferred_children: {
+            country: "county",
+          },
+        },
+      }),
+    });
+
+    await expect(fetchProfile()).resolves.toEqual({
+      locations: [
+        {
+          code: "ke",
+          level: "country",
+          name: "Kenya",
+        },
+      ],
+      preferredChildren: {
+        country: "county",
+      },
+    });
+  });
+});

--- a/apps/pesayetu/src/pages/explore/[[...slug]].js
+++ b/apps/pesayetu/src/pages/explore/[[...slug]].js
@@ -102,6 +102,14 @@ export async function getStaticProps({ preview, previewData, params }) {
     .split("-vs-")
     .map((c) => c.trim())
     .filter((c) => c);
+  // `locations` from fetchProfile() is treated as the authoritative set of
+  // supported codes. A healthy backend returns the complete list; a partially
+  // degraded response (non-empty but incomplete) could make a valid code look
+  // missing and cache it as a 404 during revalidation. We can't distinguish
+  // "removed" from "degraded" without an upstream completeness signal, so this
+  // remains a known edge case (fully empty/malformed responses throw earlier in
+  // fetchProfile and are protected). See the ISR failure-handling notes in the
+  // PR that introduced this guard.
   if (!geoCodes.every((gC) => locationCodes.includes(gC))) {
     return {
       notFound: true,

--- a/apps/pesayetu/src/utils/fetchJson.js
+++ b/apps/pesayetu/src/utils/fetchJson.js
@@ -1,5 +1,15 @@
 async function fetchJson(resource, init) {
-  return fetch(resource, init).then((res) => res.json());
+  const response = await fetch(resource, init);
+
+  if (!response.ok) {
+    throw new Error(
+      `Request to ${resource} failed with status ${response.status}${
+        response.statusText ? ` ${response.statusText}` : ""
+      }`,
+    );
+  }
+
+  return response.json();
 }
 
 export default fetchJson;


### PR DESCRIPTION
## Problem

`/explore/[code]` pages in pesayetu are ISR-generated (`revalidate: 300s`, `fallback: "blocking"`). `getStaticProps` treats the `featured_locations` list from `fetchProfile()` as the authoritative set of valid location codes:

```js
const locationCodes = locations.map(({ code }) => code);
if (!geoCodes.every((gC) => locationCodes.includes(gC))) {
  return { notFound: true };
}
```

When HURUmap returned an HTTP error, or a `200` with an **empty** `featured_locations`, the old code path silently produced `locations: []`. Every real code then failed the membership check, so `getStaticProps` returned `{ notFound: true }`.

During **background revalidation**, `notFound` doesn't just fail the request — Next.js **evicts the existing cached page and replaces it with a 404**. So a transient backend blip turned a healthy, previously-rendered page into a hard 404 until the next successful regeneration.

Root cause: a backend failure was being interpreted as "this geography does not exist" instead of "we couldn't fetch data right now."

## Fix

Make failure loud so ISR does the right thing (a thrown error during revalidation makes Next.js keep serving the last-good cached page):

- **`fetchJson`** now throws on non-ok responses instead of calling `res.json()` on the error body. The failing URL is included in the message for server-side ISR logs.
- **`fetchProfile`** now throws when `featured_locations` is missing or empty, instead of returning an empty list that downstream code misreads as "no such location."

A genuinely unknown code (valid, complete config that simply doesn't contain it) still correctly returns a 404.

## ISR failure handling

HURUmap HTTP errors and malformed/empty profile configurations now throw instead of being interpreted as missing geography data. Resulting behavior:

| Situation | Result |
| --- | --- |
| Initial build and HURUmap fails | Build fails |
| First runtime generation and HURUmap fails | Request fails; nothing is cached |
| ISR revalidation and HURUmap fails | Existing cached page remains available |
| Valid, complete configuration does not contain the code | Page becomes a 404 |

Failing the build on an empty or invalid profile configuration is intentional. It prevents deploying an apparently successful build with no pre-generated explore routes and deferring every route to runtime generation.

## Known limitation

A non-empty `featured_locations` response is currently assumed to be complete. If HURUmap returns a partially degraded response — for example `[ke]` instead of its normal complete location list — a valid location omitted from that response could still be treated as missing and cached as a 404 during revalidation.

Resolving this safely requires an authoritative way to establish completeness (a response revision/count, a documented atomic-response guarantee, or a reliable distinction between genuine geography 404s and upstream infrastructure failures). Until then, malformed and fully empty responses are protected, while partially complete responses remain a known edge case. This assumption is documented inline at the membership check.

## Blast radius of the `fetchJson` change

`fetchJson` is shared by four other call sites; all handle the new throwing behavior safely:

- `fetchSourceAfricaDocuments` / `fetchOpenAfricaDatasets` — wrap the call in `try/catch` and fall back to the original source (behavior is strictly improved: an error body can no longer be mistaken for results).
- `useProfileGeography` (SWR) — a thrown error now correctly populates SWR's `error` state.
- `fetchProfileGeography` — HTTP errors now throw, preserving the cache under ISR.

## Testing

- Added unit tests for `fetchProfile`: throws on HTTP error, throws on empty `featured_locations`, and normalizes codes on a valid profile.
- `pnpm jest --filter=pesayetu` passes (3/3); lint clean.

## Notes

- No changeset: `pesayetu` is `private`.
- The page-level ISR behavior (throw → cache preserved) is Next.js framework behavior and is not unit-tested here; the unit tests cover the data-layer contract that drives it.