### PR TITLE
fix(pesayetu): restore Payload resolution and compile coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,12 @@ jobs:
       - name: Test
         run: pnpm test:ci
 
+      # Compile opted-in apps without prerendering pages. This keeps module
+      # resolution and bundler compilation deterministic when full builds read
+      # from live services.
+      - name: Compile apps
+        run: pnpm build:compile
+
       # TODO: Re-enable build in a dedicated CI build cleanup PR. The current
       # build surface needs app-scoped env isolation for Payload/Next apps.
       - name: Build

--- a/apps/pesayetu/jsconfig.json
+++ b/apps/pesayetu/jsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@/commons-ui/core/*": ["../../packages/commons-ui-core/src/*"],
       "@/commons-ui/next/*": ["../../packages/commons-ui-next/src/*"],
+      "@/commons-ui/payload/*": ["../../packages/commons-ui-payload/src/*"],
       "@/hurumap/core/*": ["../../packages/hurumap-core/src/*"],
       "@/hurumap/next/*": ["../../packages/hurumap-next/src/*"],
       "@/pesayetu/*": ["./src/*"]

--- a/apps/pesayetu/next.config.js
+++ b/apps/pesayetu/next.config.js
@@ -26,6 +26,7 @@ module.exports = {
   transpilePackages: [
     "@commons-ui/core",
     "@commons-ui/next",
+    "@commons-ui/payload",
     "@hurumap/core",
     "@hurumap/next",
   ],

--- a/apps/pesayetu/package.json
+++ b/apps/pesayetu/package.json
@@ -28,6 +28,7 @@
     "jest": "jest --passWithNoTests",
     "playwright": "npx playwright test --pass-with-no-tests",
     "build": "next build",
+    "build:compile": "next build --experimental-build-mode compile",
     "start": "next start",
     "clean": "rm -rf .next .turbo node_modules"
   },
@@ -35,6 +36,7 @@
     "@apollo/client": "catalog:",
     "@commons-ui/core": "catalog:",
     "@commons-ui/next": "workspace:*",
+    "@commons-ui/payload": "workspace:*",
     "@emotion/react": "catalog:",
     "@emotion/styled": "catalog:",
     "@hurumap/core": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "turbo run build",
+    "build:compile": "turbo run build:compile",
     "build-next": "turbo run build-next",
     "build-payload": "turbo run build-payload",
     "dev": "turbo run dev --parallel",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1547,6 +1547,9 @@ importers:
       '@commons-ui/next':
         specifier: workspace:*
         version: link:../../packages/commons-ui-next
+      '@commons-ui/payload':
+        specifier: workspace:*
+        version: link:../../packages/commons-ui-payload
       '@emotion/react':
         specifier: 'catalog:'
         version: 11.14.0(@types/react@18.3.28)(react@18.3.1)

--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,10 @@
       "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**"]
     },
+    "build:compile": {
+      "dependsOn": ["^build:compile"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    },
     "jest": {
       "inputs": [
         "$TURBO_DEFAULT$",


### PR DESCRIPTION
## Summary

- declare `@commons-ui/payload` as a direct PesaYetu dependency
- restore the package's internal source alias and transpile it during the Next.js build
- add an opt-in `build:compile` Turbo task and run it in CI without prerendering pages against live services

## Root cause

`@hurumap/next` imports `@commons-ui/payload`, whose source uses the `@/commons-ui/payload/*` alias. PesaYetu neither declared the package directly nor configured that alias/transpilation boundary. The full monorepo workspace masked parts of the package relationship, while Webpack failed deterministically with unresolved `@/commons-ui/payload/*` imports.

The repository's full build is currently disabled because several applications require build-time services, so this module-resolution regression was not covered in CI.

## Impact

PesaYetu now compiles successfully in both the native and legacy Docker build paths. Opted-in applications can use Next.js compile-only mode through Turbo, allowing CI to catch module-resolution and bundler failures without depending on live WordPress, HURUmap, or Payload data during prerendering.

The complete PesaYetu build currently proceeds past compilation and is then blocked by a confirmed upstream HURUmap outage: the profile endpoint returns HTTP 200, while geography endpoints return HTTP 500. This PR preserves the existing fail-loud ISR behavior rather than silently deploying degraded geography data.

## Validation

- `pnpm exec oxfmt --check package.json turbo.json apps/pesayetu/package.json apps/pesayetu/jsconfig.json apps/pesayetu/next.config.js .github/workflows/ci.yml pnpm-lock.yaml`
- `pnpm --filter pesayetu lint:check`
- `pnpm --filter pesayetu jest --runInBand` — 3 tests passed
- `pnpm build:compile` — 1 opted-in task passed
- native and legacy Docker builds both pass Webpack compilation and reach HURUmap prerendering

## Follow-up

`@commons-ui/payload`'s root export has runtime imports of Payload and Lexical packages currently declared only as dev dependencies. The current bake builder performs a full pruned install, so this does not block PesaYetu's future migration, but the package contract should be corrected before adopting production-only installs. Prefer explicit subpath exports and/or declaring Payload and Lexical as peer dependencies while retaining them for local development.